### PR TITLE
feat(frontend): unify page layouts and redesign activity cards

### DIFF
--- a/app/(frontend)/about-us/page.tsx
+++ b/app/(frontend)/about-us/page.tsx
@@ -12,27 +12,17 @@ import { motion } from 'motion/react'
 
 const AboutUsPage: React.FC = () => {
   return (
-    <>
+    <div className="flex min-h-screen flex-col">
       <Navbar />
-      <div className="w-full min-h-screen">
+      <div className="flex-1">
         {/* ── Hero Section ── */}
-        <section className="flex flex-col items-center justify-center pt-24 pb-8 px-6 md:pt-32 md:pb-12 lg:px-24">
-          <motion.h1
-            initial={{ opacity: 0, y: -20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6 }}
-            className="text-3xl md:text-4xl lg:text-5xl font-bold text-secondary-500 mb-4 md:mb-6 text-center font-khalid"
-          >
+        <section className="flex flex-col items-center justify-center pt-8 pb-6 px-6 md:pt-8 md:pb-8 lg:px-24">
+          <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold text-secondary-500 mb-4 md:mb-6 text-center font-khalid">
             مسجد جامعة باب الزوار
-          </motion.h1>
-          <motion.p
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ duration: 0.6, delay: 0.2 }}
-            className="text-lg md:text-xl text-center max-w-2xl text-muted-foreground"
-          >
+          </h1>
+          <p className="text-lg md:text-xl text-center max-w-2xl text-muted-foreground">
             منارة للعلم والإيمان داخل الحرم الجامعي، تجمع بين رسالة المسجد وخدمة الطلاب والباحثين.
-          </motion.p>
+          </p>
         </section>
 
         {/* ── History & Mission Section ── */}
@@ -41,7 +31,7 @@ const AboutUsPage: React.FC = () => {
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
           transition={{ duration: 0.8 }}
-          className="w-full flex flex-col lg:flex-row items-center gap-10 px-6 py-12 md:px-16 lg:px-24 max-w-[1440px] mx-auto"
+          className="w-full flex flex-col lg:flex-row items-center gap-10 px-6 py-12 md:px-16 lg:px-24 max-w-7xl mx-auto"
         >
           <div dir="rtl" className="w-full lg:w-1/2 flex flex-col items-start gap-6 text-right">
             <h2 className="text-3xl font-bold text-secondary-500 md:text-4xl font-khalid">تاريخنا ورسالتنا</h2>
@@ -161,7 +151,7 @@ const AboutUsPage: React.FC = () => {
         <CTASection />
       </div>
       <Footer />
-    </>
+    </div>
   )
 }
 

--- a/app/(frontend)/activities/_components/ActivityCard.tsx
+++ b/app/(frontend)/activities/_components/ActivityCard.tsx
@@ -1,57 +1,192 @@
-import React from 'react'
-import { Card } from '@/components/ui/card'
+'use client'
+
+import React, { useState } from 'react'
 import Image from 'next/image'
-import { ArrowLeft, Calendar } from 'lucide-react'
-import { Button } from '@/components/ui/button'
-import { Activity, Media } from '@/payload-types'
-import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import { format } from 'date-fns'
 import { arDZ } from 'date-fns/locale'
+import { MapPin, Calendar, Clock, Users, Heart, MessageCircle, Share2, Bookmark } from 'lucide-react'
+import { Activity, Media } from '@/payload-types'
 import { getImageUrl } from '@/utils/image-utils'
+import { activitiesTypesConfig } from '@/utils/constants/activities'
 
 interface ActivityCardProps {
   activity: Activity
+  className?: string
 }
 
-const ActivityCard: React.FC<ActivityCardProps> = ({ activity }) => {
-  const media = activity.image as Media
+const ActivityCard: React.FC<ActivityCardProps> = ({ activity, className }) => {
+  const router = useRouter()
+  const [isLiked, setIsLiked] = useState(false)
+  const [isBookmarked, setIsBookmarked] = useState(false)
+  const [isShared, setIsShared] = useState(false)
+
+  const media = activity.image as Media | undefined
   const imageUrl = getImageUrl(media?.url)
+  const typeLabel = activitiesTypesConfig[activity.type] ?? 'نشاط'
+  const audience = activity.targetAudience?.map((a) => a.name).filter(Boolean).join(' • ') || 'الجميع'
+  const scheduleCount = activity.schedules?.length ?? 0
+  const startLabel = activity.startDate
+    ? format(new Date(activity.startDate), 'dd/MM/yyyy', { locale: arDZ })
+    : 'غير محدد'
+
+  const open = activity.openForRegistration === true
+  const badgeText = open ? 'قائم' : 'مكتمل'
+  const badgeClassName = open
+    ? 'bg-success-50'
+    : 'bg-[#24324580]'
+
+  const details = [
+    { icon: MapPin, text: activity.location || 'في مسجد الجامعة', label: 'الموقع' },
+    { icon: Calendar, text: `ابتداء من ${startLabel}`, label: 'تاريخ البداية' },
+    { icon: Clock, text: scheduleCount > 0 ? `${scheduleCount} لقاءات` : 'لقاءات متعددة', label: 'المدة' },
+    { icon: Users, text: audience, label: 'الفئة' },
+  ]
+
+  const handleShare = async (): Promise<void> => {
+    const shareData = {
+      title: activity.title,
+      text: activity.shortDescription,
+    }
+
+    try {
+      if (navigator.share) {
+        await navigator.share(shareData)
+      } else if (navigator.clipboard) {
+        await navigator.clipboard.writeText(`${shareData.title} - ${shareData.text}`)
+      }
+      setIsShared(true)
+      window.setTimeout(() => setIsShared(false), 2000)
+    } catch {
+      setIsShared(false)
+    }
+  }
+
+  const handleOpen = (): void => {
+    router.push(`/activities/${activity.id}`)
+  }
+
   return (
-    <Card className="flex flex-col md:flex-row">
-      <div className="relative w-full md:w-[400px] h-48 md:h-75 flex-shrink-0">
-        <Image
-          src={imageUrl}
-          alt={media?.alt || ''}
-          fill
-          className="object-cover rounded-t-xl md:rounded-l-xl md:rounded-tr-none"
-          sizes="(max-width: 768px) 100vw, 50vw"
-        />
-      </div>
-      <div className="flex flex-col justify-between p-4 md:p-8 flex-1">
-        <div>
-          <div className="mb-3 sm:mb-4 flex items-center gap-2">
-            <Calendar className="text-primary size-4 sm:size-5 md:size-6" />
-            <p className="text-foreground text-xs sm:text-sm md:text-base font-bold">
-              {activity.startDate
-                ? format(new Date(activity.startDate), 'EEEE d MMMM yyyy', {
-                    locale: arDZ,
-                  })
-                : 'تاريخ غير محدد'}
+    <article
+      dir="rtl"
+      className={`group/activity relative flex h-[390px] w-full items-start justify-end overflow-hidden rounded-2xl border border-solid border-stroke-grey bg-fill-white transition-all duration-300 hover:border-primary-300 hover:shadow-[0_8px_30px_rgba(10,175,146,0.15)] ${className}`}
+      aria-labelledby={`activity-title-${activity.id}`}
+    >
+      <button
+        type="button"
+        onClick={handleOpen}
+        className="relative flex h-full w-[45%] max-w-[500px] flex-none shrink-0 cursor-pointer self-stretch overflow-hidden border-l border-l-stroke-grey bg-cover bg-[50%_50%] sm:w-[40%]"
+        role="img"
+        aria-label={`صورة نشاط ${activity.title}`}
+      >
+        {imageUrl && (
+          <Image
+            src={imageUrl}
+            alt={media?.alt || activity.title}
+            fill
+            className="object-cover transition-transform duration-500 group-hover/activity:scale-105"
+            sizes="(max-width: 640px) 45vw, (max-width: 1024px) 40vw, 500px"
+          />
+        )}
+        <span className={`absolute top-[18px] right-[18px] z-10 flex h-fit w-fit items-center justify-center gap-[5.36px] rounded-lg border border-solid border-fill-white/10 px-[15px] py-1 shadow-[inset_0_1px_0_rgba(255,255,255,0.40),inset_1px_0_0_rgba(255,255,255,0.32),inset_0_-1px_4px_rgba(0,0,0,0.13),inset_-1px_0_4px_rgba(0,0,0,0.11)] backdrop-blur-[6px] ${badgeClassName}`}>
+          <span className="relative flex w-fit items-center justify-center text-center font-khalid text-sm font-normal leading-[normal] text-fill-white">
+            {badgeText}
+          </span>
+        </span>
+      </button>
+
+      <div className="relative flex flex-1 grow flex-col items-end justify-between self-stretch px-6 py-5 pt-6 pb-7 md:px-8">
+        <div className="relative flex w-full flex-none flex-col items-start gap-4 self-stretch">
+          <section
+            className="relative flex w-full flex-col items-start gap-3 self-stretch"
+            aria-label="معلومات النشاط"
+          >
+            <div className="flex flex-wrap items-start justify-end gap-2 self-stretch" aria-label="تصنيفات النشاط">
+              <span className="relative inline-flex h-7 flex-none items-center justify-center gap-2.5 rounded-lg bg-primary-main-15 px-3 py-1">
+                <span className="relative flex w-fit items-center justify-center whitespace-nowrap text-center font-alyamama text-sm font-normal leading-[14px] tracking-[0.14px] text-primary-300">
+                  {typeLabel}
+                </span>
+              </span>
+            </div>
+            <h2
+              id={`activity-title-${activity.id}`}
+              className="relative w-fit max-w-full items-center self-start text-2xl leading-[26.4px] font-khalid text-blue-400 line-clamp-1"
+            >
+              {activity.title}
+            </h2>
+            <p className="relative flex w-full items-start justify-end self-stretch font-alyamama text-sm leading-[20.3px] text-blue-300 line-clamp-2">
+              {activity.shortDescription}
             </p>
+            <dl className="grid h-fit grid-cols-2 grid-flow-row gap-[10px_16px] p-3 rounded-[10px] border border-solid border-stroke-grey bg-fill-contrast">
+              {details.map((detail) => {
+                const Icon = detail.icon
+                return (
+                  <div
+                    key={detail.label}
+                    className="flex h-full w-full items-center justify-end gap-1.5"
+                  >
+                    <dt className="sr-only">{detail.label}</dt>
+                    <dd className="flex w-fit items-center justify-end whitespace-nowrap font-alyamama text-xs leading-3 text-blue-300">
+                      {detail.text}
+                    </dd>
+                    <Icon className="h-5 w-5 flex-none text-blue-200" aria-hidden="true" />
+                  </div>
+                )
+              })}
+            </dl>
+          </section>
+        </div>
+
+        <footer className="relative flex w-full flex-none items-center justify-between self-stretch px-2 py-0">
+          <div className="inline-flex items-center gap-5">
+            <button
+              type="button"
+              className="inline-flex items-center gap-1.5 cursor-pointer"
+              aria-label={isLiked ? 'إزالة الإعجاب' : 'الإعجاب بالنشاط'}
+              aria-pressed={isLiked}
+              onClick={() => setIsLiked((current) => !current)}
+            >
+              <Heart
+                className={`h-[18px] w-[18px] transition-colors ${isLiked ? 'text-danger fill-danger' : 'text-blue-200'}`}
+                aria-hidden="true"
+              />
+              <span className="font-alyamama text-xs leading-3 text-blue-300">{isLiked ? 195 : 194}</span>
+            </button>
+            <button
+              type="button"
+              className="inline-flex items-center gap-1.5 cursor-pointer"
+              aria-label="عرض التعليقات"
+              onClick={handleOpen}
+            >
+              <MessageCircle className="h-[18px] w-[18px] text-blue-200" aria-hidden="true" />
+              <span className="font-alyamama text-xs leading-3 text-blue-300">13</span>
+            </button>
           </div>
-          <p className="mb-2 sm:mb-3 text-foreground text-lg sm:text-xl md:text-2xl font-bold line-clamp-2">{activity.title}</p>
-          <p className="text-muted-foreground text-xs sm:text-sm line-clamp-2 sm:line-clamp-3">{activity.shortDescription}</p>
-        </div>
-        <div className="mt-3 sm:mt-4">
-          <Link href={`/activities/${activity.id}`}>
-            <Button variant="link" className="p-0 h-auto text-xs sm:text-sm md:text-xl font-bold">
-              <span>اقرأ المزيد</span>
-              <ArrowLeft className="text-primary size-4 sm:size-5 md:size-6 mr-1" />
-            </Button>
-          </Link>
-        </div>
+          <div className="inline-flex items-center gap-5">
+            <button
+              type="button"
+              className="cursor-pointer"
+              aria-label={isShared ? 'تمت مشاركة النشاط' : 'مشاركة النشاط'}
+              onClick={handleShare}
+            >
+              <Share2 className={`h-[18px] w-[18px] ${isShared ? 'text-primary-300' : 'text-blue-200'}`} aria-hidden="true" />
+            </button>
+            <button
+              type="button"
+              className="cursor-pointer"
+              aria-label={isBookmarked ? 'إزالة النشاط من المحفوظات' : 'حفظ النشاط'}
+              aria-pressed={isBookmarked}
+              onClick={() => setIsBookmarked((current) => !current)}
+            >
+              <Bookmark
+                className={`h-[18px] w-[18px] ${isBookmarked ? 'text-primary-300 fill-primary-300' : 'text-blue-200'}`}
+                aria-hidden="true"
+              />
+            </button>
+          </div>
+        </footer>
       </div>
-    </Card>
+    </article>
   )
 }
 

--- a/app/(frontend)/activities/_components/ActivitySkeleton.tsx
+++ b/app/(frontend)/activities/_components/ActivitySkeleton.tsx
@@ -1,34 +1,49 @@
 import React from 'react'
-import { Card, CardContent } from '@/components/ui/card'
 import { Skeleton } from '@/components/ui/skeleton'
 
 const ActivitySkeleton: React.FC = () => {
   return (
-    <Card className="overflow-hidden">
-      <CardContent className="p-0 flex flex-col md:flex-row">
-        <Skeleton className="w-full h-100vh flex-1 rounded-none" />
+    <article
+      dir="rtl"
+      className="relative flex h-[390px] w-full items-start justify-end overflow-hidden rounded-2xl border border-solid border-stroke-grey bg-fill-white"
+    >
+      <div className="relative h-full w-[45%] max-w-[500px] flex-none shrink-0 self-stretch border-l border-l-stroke-grey sm:w-[40%]">
+        <Skeleton className="absolute inset-0 rounded-none" />
+        <Skeleton className="absolute top-[18px] right-[18px] z-10 h-7 w-16 flex-none rounded-lg bg-success-50" />
+      </div>
 
-        <div className="flex-2 flex flex-col justify-between p-8 space-y-6">
-          <div>
-            <div className="mb-6 flex items-center gap-2.5">
-              <Skeleton className="size-6 rounded-full" />
-              <Skeleton className="h-5 w-32" />
+      <div className="relative flex flex-1 grow flex-col items-end justify-between self-stretch px-6 py-5 pt-6 pb-7 md:px-8">
+        <div className="relative flex w-full flex-none flex-col items-start gap-4 self-stretch">
+          <section className="relative flex w-full flex-col items-start gap-3 self-stretch">
+            <div className="flex flex-wrap items-start justify-end gap-2 self-stretch">
+              <Skeleton className="h-7 w-16 flex-none rounded-lg bg-primary/15" />
             </div>
-            <Skeleton className="h-8 w-3/4 mb-4" />
+            <Skeleton className="h-7 w-[70%] self-start rounded-md" />
+            <Skeleton className="h-4 w-full self-start" />
+            <Skeleton className="h-4 w-3/4 self-start" />
+            <div className="grid h-fit w-full grid-cols-2 gap-[10px_16px] rounded-[10px] border border-solid border-stroke-grey bg-fill-contrast p-3">
+              {Array.from({ length: 4 }).map((_, index) => (
+                <div key={index} className="flex h-full w-full items-center justify-end gap-1.5">
+                  <Skeleton className="h-4 w-20" />
+                  <Skeleton className="h-5 w-5 flex-none rounded-full" />
+                </div>
+              ))}
+            </div>
+          </section>
+        </div>
 
-            <div className="space-y-3">
-              <Skeleton className="h-4 w-full" />
-              <Skeleton className="h-4 w-full" />
-              <Skeleton className="h-4 w-2/3" />
-            </div>
+        <div className="relative flex w-full flex-none items-center justify-between self-stretch px-2 py-0">
+          <div className="inline-flex items-center gap-5">
+            <Skeleton className="h-[18px] w-12" />
+            <Skeleton className="h-[18px] w-12" />
           </div>
-
-          <div className="pt-4">
-            <Skeleton className="h-10 w-40 rounded-md" />
+          <div className="inline-flex items-center gap-5">
+            <Skeleton className="h-[18px] w-[18px] rounded-full" />
+            <Skeleton className="h-[18px] w-[18px] rounded-full" />
           </div>
         </div>
-      </CardContent>
-    </Card>
+      </div>
+    </article>
   )
 }
 

--- a/app/(frontend)/activities/page.tsx
+++ b/app/(frontend)/activities/page.tsx
@@ -35,8 +35,8 @@ const ActivitiesPage: React.FC = () => {
       <div className="flex flex-col space-y-8 sm:space-y-12 lg:space-y-14">
         <div className="flex flex-col items-center justify-center gap-8 sm:gap-10 lg:gap-12 px-4">
           <div className="space-y-3 sm:space-y-4 text-center">
-            <p className="text-secondary text-3xl sm:text-4xl md:text-5xl lg:text-5xl text-center font-khalid">أنشطة المسجد</p>
-            <p className="text-foreground text-sm sm:text-base md:text-xl text-center max-w-2xl">
+            <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold text-secondary-500 mb-4 md:mb-6 text-center font-khalid">أنشطة المسجد</h1>
+            <p className="text-lg md:text-xl text-center max-w-2xl text-muted-foreground">
               مجموعة من النشاطات الدعوية والتعليمية والاجتماعية التي تهدف إلى بناء مجتمع واعٍ، متآلف، يسير على هدي الإسلام.
             </p>
           </div>

--- a/app/(frontend)/articles/page.tsx
+++ b/app/(frontend)/articles/page.tsx
@@ -5,14 +5,14 @@ import { Pagination } from '@/components/common/Pagination'
 import ListingContent from '@/components/listing/ListingContent'
 import ListingToolbar from '@/components/listing/listing-toolbar/ListingToolbar'
 import ListingRenderer from '@/components/listing/ListingRenderer'
-import ArticleCard from './_components/ArticleCard'
+import BlogArticleCard from '@/components/ui/landing/BlogArticleCard'
 import { useSearch } from '@/hooks/use-search'
 import { ArticleSearchParams, ArticleType } from '@/interfaces/articles.interfaces'
 import EmptyData from '@/components/common/EmptyData'
 import ErrorData from '@/components/common/ErrorData'
 import { useGetArticlesQuery } from '@/lib/apis/articles/queries'
 import { articleTypesConfigArray } from '@/utils/constants/articles'
-import ArticleSkeleton from './_components/ArticleSkeleton'
+import ArticleCardSkeleton from '@/components/ui/landing/ArticleCardSkeleton'
 import { Tag } from 'lucide-react'
 
 const ArticlesPage: React.FC = () => {
@@ -35,8 +35,8 @@ const ArticlesPage: React.FC = () => {
       <div className="flex flex-col space-y-14">
         <div className="flex flex-col items-center justify-center gap-12">
           <div className="space-y-4">
-            <p className="text-secondary text-5xl text-center font-khalid">مقالات المسجد</p>
-            <p className="text-foreground text-xl text-center">
+            <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold text-secondary-500 mb-4 md:mb-6 text-center font-khalid">مقالات المسجد</h1>
+            <p className="text-lg md:text-xl text-center max-w-2xl text-muted-foreground">
               مجموعة من المقالات التي تضيء الفكر وتقرّب القلب إلى الله، تجمع بين الحكمة، والمعرفة،
               وجمال الكلمة الهادفة.
             </p>
@@ -72,16 +72,16 @@ const ArticlesPage: React.FC = () => {
             emptyFallback={<EmptyData title="لم يتم العثور على أي مقالات" />}
             errorFallback={<ErrorData />}
             loader={
-              <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+              <div className="mx-auto grid w-full max-w-[1200px] grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
                 {Array.from({ length: 12 }).map((_, index) => (
-                  <ArticleSkeleton key={index} />
+                  <ArticleCardSkeleton key={index} />
                 ))}
               </div>
             }
           >
-            <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+            <div className="mx-auto grid w-full max-w-[1200px] grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
               {articles.map((article) => (
-                <ArticleCard key={article.id} article={article} />
+                <BlogArticleCard key={article.id} article={article} />
               ))}
             </div>
             <Pagination

--- a/app/(frontend)/contact-us/page.tsx
+++ b/app/(frontend)/contact-us/page.tsx
@@ -3,24 +3,19 @@
 import React from 'react'
 import Navbar from '@/components/layouts/navbar/Navbar'
 import Footer from '@/components/layouts/Footer'
-import { motion } from 'motion/react'
 import { MapPin, Mail, MessageCircle, MessagesSquare, Instagram, Facebook } from 'lucide-react'
 import Image from 'next/image'
 import Link from 'next/link'
 
 const ContactUsPage: React.FC = () => {
   return (
-    <>
+    <div className="flex min-h-screen flex-col">
       <Navbar />
-      <div className="w-full min-h-screen">
-        <section className="w-full px-6 py-12 md:px-16 lg:px-24 pt-32 max-w-[1400px] mx-auto mb-8">
+      <div className="w-full flex-1">
+        <section className="w-full px-6 pt-8 md:px-16 lg:px-24 max-w-7xl mx-auto mb-8">
           <div className="grid grid-cols-1 lg:grid-cols-[1.8fr_1fr] gap-8">
             {/* Right Column: Direct Messaging */}
-            <motion.div
-              initial={{ opacity: 0, x: 30 }}
-              whileInView={{ opacity: 1, x: 0 }}
-              viewport={{ once: true }}
-              transition={{ duration: 0.8 }}
+            <div
               className="bg-white rounded-[20px] p-12 shadow-sm border border-gray-100 flex flex-col items-center justify-center text-center gap-8"
             >
               <div className="w-20 h-20 rounded-full bg-primary-main-10 flex items-center justify-center text-primary-300 mb-4">
@@ -67,15 +62,11 @@ const ContactUsPage: React.FC = () => {
                   </a>
                 ))}
               </div>
-            </motion.div>
+            </div>
 
             {/* Left Column: Contact Info & Map */}
             <div className="flex flex-col gap-8">
-              <motion.div
-                initial={{ opacity: 0, x: -30 }}
-                whileInView={{ opacity: 1, x: 0 }}
-                viewport={{ once: true }}
-                transition={{ duration: 0.8 }}
+              <div
                 dir="rtl"
                 className="bg-white rounded-[20px] p-10 shadow-sm border border-gray-100 flex flex-col gap-8 h-full"
               >
@@ -102,13 +93,9 @@ const ContactUsPage: React.FC = () => {
                     </div>
                   </div>
                 </div>
-              </motion.div>
+              </div>
 
-              <motion.div
-                initial={{ opacity: 0, scale: 0.95 }}
-                whileInView={{ opacity: 1, scale: 1 }}
-                viewport={{ once: true }}
-                transition={{ duration: 0.8, delay: 0.2 }}
+              <div
                 className="relative w-full h-full rounded-[20px] overflow-hidden shadow-sm border border-gray-100 bg-fill-contrast group"
               >
                 <Link
@@ -129,13 +116,13 @@ const ContactUsPage: React.FC = () => {
                     </span>
                   </div>
                 </Link>
-              </motion.div>
+              </div>
             </div>
           </div>
         </section>
       </div>
       <Footer />
-    </>
+    </div>
   )
 }
 

--- a/app/(frontend)/library/page.tsx
+++ b/app/(frontend)/library/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 import React, { useEffect, useState } from 'react'
 import Layout from '@/components/layouts'
-import BookCard from './_components/BookCard'
 import { Pagination } from '@/components/common/Pagination'
 import { Button } from '@/components/ui/button'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -12,7 +11,8 @@ import { useGetBooksQuery } from '@/lib/apis/books/queries'
 import { useSearch } from '@/hooks/use-search'
 import { BookSearchParams, BookCategory, BookType } from '@/interfaces/books.interfaces'
 import { languagesConfigArray, availabilityConfigArray } from '@/utils/constants/data'
-import BookCardSkeleton from './_components/BookCardSkeleton'
+import BookCard from '@/components/ui/landing/BookCard'
+import BookCardSkeleton from '@/components/ui/landing/BookCardSkeleton'
 import EmptyData from '@/components/common/EmptyData'
 import ErrorData from '@/components/common/ErrorData'
 import { bookTypesConfigArray } from '@/utils/constants/books'
@@ -48,8 +48,8 @@ const LibraryPage: React.FC = () => {
       <div className="flex flex-col space-y-8 sm:space-y-12 lg:space-y-14">
         <div className="flex flex-col items-center justify-center gap-8 sm:gap-10 lg:gap-12 px-4">
           <div className="space-y-3 sm:space-y-4 text-center">
-            <p className="text-secondary text-3xl sm:text-4xl md:text-5xl lg:text-5xl text-center font-khalid">مكتبة المسجد</p>
-            <p className="text-foreground text-sm sm:text-base md:text-xl text-center max-w-2xl">
+            <h1 className="text-3xl md:text-4xl lg:text-5xl font-bold text-secondary-500 mb-4 md:mb-6 text-center font-khalid">مكتبة المسجد</h1>
+            <p className="text-lg md:text-xl text-center max-w-2xl text-muted-foreground">
               استكشف الكنوز المعرفية والكتب النادرة في مكتبة المسجد, متاحة للمطالعة والإستعارة.
             </p>
           </div>
@@ -118,14 +118,14 @@ const LibraryPage: React.FC = () => {
             emptyFallback={<EmptyData title="لم يتم العثور على أي كتب" />}
             errorFallback={<ErrorData />}
             loader={
-              <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 sm:gap-4 lg:gap-4">
+              <div className="mx-auto grid w-full max-w-[1200px] grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
                 {Array.from({ length: 12 }).map((_, index) => (
                   <BookCardSkeleton key={index} />
                 ))}
               </div>
             }
           >
-            <div className="grid grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 sm:gap-4 lg:gap-4">
+            <div className="mx-auto grid w-full max-w-[1200px] grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-4">
               {books.map((book) => (
                 <BookCard key={book.id} book={book} />
               ))}

--- a/components/layouts/index.tsx
+++ b/components/layouts/index.tsx
@@ -3,14 +3,23 @@ import Footer from './Footer'
 import Navbar from './navbar/Navbar'
 import { cn } from '@/lib/utils'
 
-const Layout: React.FC<React.PropsWithChildren & { className?: string }> = ({
+const Layout: React.FC<React.PropsWithChildren & { className?: string; containerClassName?: string }> = ({
   children,
   className,
+  containerClassName,
 }) => {
   return (
-    <div>
+    <div className="flex min-h-screen flex-col">
       <Navbar />
-      <div className={cn('container mx-auto py-8', className)}>{children}</div>
+      <div
+        className={cn(
+          'mx-auto w-full max-w-7xl flex-1 px-6 py-8 lg:px-16',
+          containerClassName,
+          className,
+        )}
+      >
+        {children}
+      </div>
       <Footer />
     </div>
   )

--- a/components/layouts/navbar/Navbar.tsx
+++ b/components/layouts/navbar/Navbar.tsx
@@ -86,9 +86,9 @@ const Navbar: React.FC = () => {
       <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4 lg:px-16">
         <Link href="/" className="shrink-0">
           <Image
-            src="/static/images/logo-icon.svg"
+            src="/static/images/logo-horizontal.svg"
             alt="الشعار"
-            width={23}
+            width={90}
             height={40}
             className="h-10 w-auto"
           />

--- a/docs/PRD-open-decisions.md
+++ b/docs/PRD-open-decisions.md
@@ -1,0 +1,137 @@
+# Open Decisions — Review Checklist (Design Team)
+
+**Companion to:** `docs/PRD.md` (§10 Open Decisions)
+
+**Purpose:** Each item below must be answered before build starts. Answers unlock P0 (loan state machine, notifications, multi-copy model, book-requests) and unblock the admin panel. Add a decision date + owner column.
+
+**Instructions for the reviewer:** For each decision, pick an option (or write your own) and mark one of: ✅ confirmed / ❌ reject / 🔄 needs revision.
+
+---
+
+## Resolved (✅)
+
+| ID | Decision | Resolution |
+|---|---|---|
+| D9 | Notification delivery | **SSE** + sync email hook (provider TBD) |
+| D12 | Admin manual add | Search by **name/email** (no matricule field) |
+| D13 | User certificate | **Store in v1**; display in admin Users → profile info |
+| — | Extension auto | **Auto-approve when queue empty** |
+| — | Loan duration | **Configurable** (default 14 days) in Settings |
+| — | Borrow limit | **Configurable** max concurrent loans |
+| — | Publisher role | **None** — all admins edit all content |
+| — | Deployment | **Docker/VPS** |
+| — | Scale | **Thousands** of users |
+| — | Language | **Arabic-only** v1 |
+| — | Admin panel location | Stays under **/admin** |
+| — | Password reset / 2FA | **Deferred** |
+
+---
+
+### D1 — Pickup window behavior
+When a borrower's request is approved, a **pickup window** is created.
+- **Duration:** 24h / 48h / 72h / other
+- **Reschedule allowed?** How many times? Who can do it (user, admin, both)?
+- **Exact `no_show` trigger:** window expires without pickup → auto `no_show`?
+
+### D2 — No-show threshold & restriction
+- **Threshold:** after how many no-shows does the user get restricted? (default proposal: **2**)
+- **Restriction scope:** block new borrows? all borrows? only hold reservations?
+- **Duration:** fixed days / until review / permanent?
+
+### D3 — "Finishing reading" trigger (article feedback popup)
+The popup appears "after finishing reading". Define the trigger:
+- **Scroll to 100%** of content
+- Min **read time** (e.g., ≥60s) AND scroll threshold
+- **Manual button** ("أتممت القراءة")
+- Combination? Which one wins if conflicting (e.g., user scrolls fast)?
+
+### D4 — Article reviews vs like/dislike feedback
+Conflict between §6.7 (article review) and §7.8 (feedback likes/dislikes).
+- Are they the **same mechanism**? (choose one)
+- Or **two distinct** things (a 1–5 written review AND a quick like/dislike)?
+- If two: where does each appear on the reading page? Does the admin Reviews section (§7.10) manage both?
+
+### D5 — Activity overflow behavior
+When an activity is at max capacity and a user tries to register:
+- **Waitlist** (mirror book waitlist; auto-promote on spot + notify)
+- **Hard refusal** ("نشاط مكتمل", no waitlist)
+- Waitlist with consent popup?
+
+### D6 — Extension policy
+- **Eligibility window:** how many days before due can user request? (e.g., 3–7 days before due)
+- **Max extensions per loan:** 1 / 2 / unlimited
+- **Max total loan duration** (base + extensions): default proposal 2× base.
+- **Auto vs manual:** user requests → admin approves (current §4), or auto-approve when queue empty?
+
+### D7 — Multi-copy model
+"Same book, more copies, same id" — decide the data shape:
+- **Keep counters** (`totalBooks`/`availableBooks`) — copies NOT individually tracked; copy code generated at pickup. (simplest)
+- **Per-copy records** (sub-document per physical copy) — enables per-copy codes, damage tracking (v2), on-site (v2).
+
+### D8 — Cancelability rules (per operation)
+Define cancel windows + side effects for:
+- **Book request** (before pickup? role? freed copy re-released to waitlist?)
+- **Extension request** (before approval only? after approval cannot cancel?)
+- **Activity registration** (before deadline? frees a spot → notify overflow?)
+- **Pending pickup** (before `picked` only?)
+
+### D9 — Notification delivery ✅ resolved
+- **Frontend channel:** **SSE** (authenticated endpoint, one connection per logged-in user). Polling fallback if SSE drops (e.g., 60s) — decide with engineering.
+- **Email strategy:** sync send from the same hook on create; provider TBD. Failure policy (retry? fallback to in-app only?) still open.
+- **Bulk audiences** ("new activity"/"new article" to all users): in-app + **digest email** (daily/on-demand).
+
+### D10 — 2FA & admin security
+Design exists for admin settings §7.9 (must verify identity first).
+- **In v1 or deferred?**
+- If in: which 2FA method (TOTP app / email OTP / both)? Applies to admin only or all users?
+
+### D11 — "Request a non-existing book" (user)
+- **New collection** `book-requests` (title, author, submittedBy, status) — confirm.
+- **Lifecycle:** submitted → reviewed → (procured → added to catalog) / refused. Who closes it? Does the requester get notified on each transition?
+- **Relationship to waitlist:** not the same thing (this is outside the catalog) — confirm.
+
+### D12 — On-the-day admin verification flow (loans) ✅ resolved
+§7.2 duplicate-loan alert ("user has unreturned books" → accept/refuse).
+- **Acceptance** — approve anyway, warn admin.
+- **Refusal** — requires a **reason** (shown to user in notification).
+- **Manual add dialog:** search by **name/email** — **no matricule field** (confirmed: users have no matricule; manual add uses name/email search).
+
+### D13 — User certificate ✅ resolved
+Register step collects a **school certificate** file but it's currently dropped (never saved).
+- **Store in v1?** ✅ **Yes** — new `certificate` upload field on User → Media.
+- **Display location:** admin Users → profile info. User Profile → info tab (see also verification gate — borrowing blocked until verified).
+- **Verification gate:** user is **verified** when a stored certificate exists; admin resolves verification state.
+
+---
+
+## Suggested handout format
+
+| ID | Decision | Options / proposal | Choice | Notes | Owner | Date |
+|---|---|---|---|---|---|---|
+| D1 | Pickup window | 24h/48h/72h | | | | |
+| D2 | No-show threshold | proposal: 2 | | | | |
+| D3 | Finishing-reading trigger | scroll 100% / read time / manual | | | | |
+| D4 | Article reviews vs feedback | same / two mechanisms | | | | |
+| D5 | Activity overflow | waitlist / hard refusal | | | | |
+| D6 | Extension policy | eligibility + max ext | | | | |
+| D7 | Multi-copy model | counters / per-copy | | | | |
+| D8 | Cancelability rules | per operation | | | | |
+| D9 | Notification delivery | polling/SSE/WS + sync/queue | ✅ SSE | | | |
+| D10 | 2FA & admin security | v1 / deferred | ✅ deferred | revisit post-v1 | | |
+| D11 | Non-existing book request | collection + lifecycle | | | | |
+| D12 | Admin verification flow | matricule source | ✅ name/email | no matricule | | |
+| D13 | User certificate | store in v1? display? | ✅ store | + verification gate | | |
+| NEW | Loan duration | configurable | ✅ default 14d | in Settings | | |
+| NEW | Borrow limit | configurable | ✅ proposal: 3 | in Settings | | |
+| NEW | Email provider | TBD | 🔄 set later | | | |
+
+---
+
+## Recommended review order
+
+1. **D7** (multi-copy) and **D4** (reviews vs feedback) first — they shape data models.
+2. **D1, D2, D6** — loan state machine.
+3. **D3, D5, D8, D11** — feature-level.
+4. **D9 ✅, D10 ✅, D12 ✅, D13 ✅** — resolved; remaining: **email provider, borrow-limit default (proposal 3)**.
+
+Already resolved ✅: D9 (SSE), D10 (defer 2FA), D12 (name/email, no matricule), D13 (store certificate + verification gate).

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,0 +1,370 @@
+# PRD — USTHB Mosque Platform v1
+
+## 1. Overview & Scope
+
+**Vision:** A digital platform for the USTHB mosque community covering library (borrowing/waitlist/extensions/reviews), activities, articles, and notifications — with a full admin panel for management.
+
+**Guardrails (binding):**
+- **Design is final.** All UI must follow the completed design system/Figma. No new features beyond this PRD.
+- Existing implemented pages are **polish-only** — flows stay, visuals conform to design tokens.
+- Arabic-first, RTL throughout.
+
+**Audience:** stakeholders (features/priority) + engineering (flows, data contracts).
+
+**Personas:**
+
+| Persona | Description |
+|---|---|
+| **Visitor** | Not logged in. Browsing landing, library catalog, activities, articles. Can search/view detail. Auth-required actions (borrow, waitlist, register, review, favorite/bookmark) → sign-in gate + redirect back. |
+| **User (member)** | Logged-in community member. Borrow books, waitlist, extend, register for activities, review, favorite/bookmark articles & books, notifications, personal dashboard. |
+| **Admin** | Full management: loans queue, pickups, users, books, articles, activities, reviews, logs, analytics, settings. |
+| **Librarian (مداوم)** | v2 (documented as non-goal for v1). On-site borrowing, today's pickups. |
+
+**Roles & permissions model:**
+- `role: admin | user` on User (already in JWT). Visitor = unauthenticated.
+- **No publisher role** — admins can create/edit/delete any article, activity, or book.
+- **No matricule field** — admin manual-add searches by name/email instead.
+- **Verification gate:** a user is **verified** when they have a stored **school certificate** (uploaded at registration, **stored in v1** — D13 ✓). **Borrowing/checkout is blocked until verified** (browsing/waitlisting allowed). Admin resolves verification state.
+
+**Scope v1 (confirmed):**
+- User core: notifications, loans (waitlist + extension + pickup), dashboards + calendars, articles (bookmarks, feedback, reviews), onboarding/helpers.
+- Full admin panel: dashboard, loans, users, books, articles, activities, reviews, logs, analytics, settings.
+- Landing polish (force autoplay).
+- **Google OAuth** in scope; **password reset deferred** (not v1).
+
+---
+
+## 2. Non-Goals (v1 explicitly out)
+- **Librarian (مداوم) dedicated view** — v2.
+- **On-site borrowings** (reading in musalla, not taking home) — v2.
+- **User-side audit activity log** — v2 (admin logs in scope).
+- **Tasks** — v2.
+- **Book damage tracking** — v2.
+- **Password reset / forgot password** — deferred.
+- **2FA** — deferred.
+- **Multi-language / i18n** — Arabic-only for v1.
+- **External analytics tools** — analytics computed from the DB only.
+- Any feature not in this document, or any new visual element not in the approved design.
+
+---
+
+## 3. Cross-Cutting UX Specs (apply to every screen)
+- **Component skeletons** for all async views (match final card/table layouts; shimmer in design tokens).
+- **Empty states** for tables, listings, 404, and error states — use approved illustrations + CTA.
+- **Confirmation alerts** on every destructive/mutating action (delete, cancel, accept/refuse, mark-as-returned, overrides).
+- **Upload component** (profile picture, certificates) — drag-drop + validation, uses existing Media/S3.
+- **In-app toasts** via Sonner (already present) for success/error on all actions.
+- **Review KPI components** (rating summaries) reused on book and article contexts.
+
+---
+
+## 4. Loan Lifecycle State Machine (the heart)
+
+Current model only has `pending / approved / returned / overdue`. This PRD defines the full machine; waitlist, extension, pickup and on-site all become transitions, not islands.
+
+**Real-world flow (confirmed):** loans are **physical** — the book is picked up at the mosque. Flow: verified user requests → (auto-approve if a copy is free) → reservation + **pickup window** → user collects at the mosque → admin marks `picked` → due date from a **configurable duration** → admin marks `returned`. Extensions go through admin, with auto-approval when the queue is empty.
+
+States:
+
+1. `requested` (book req created; queued if no copies; user notified of state)
+2. `waitlisted` (no copy available at request time; position in queue)
+3. `approved_pickup` (copy reserved + pickup window set; "accepted borrowings" tag)
+4. `picked` (user collected the book; loan active; due date set from config)
+5. `on_site` (v2)
+6. `extension_requested` (user asks to extend)
+7. `returned` (book returned; copy released → next waitlist notified)
+8. `overdue` (past due date without return/extension; escalation)
+9. `no_show` (pickup window missed; reservation released, user warned)
+10. `cancelled` (request/registration cancelled by user or admin)
+
+**Key transitions & system actions (locked rules):**
+
+- **Request & approval:** preconditions to request — user is **verified** AND **under the configurable borrow limit** (max concurrent loans). If `availableBooks > 0` → **auto-approve** → `approved_pickup` + pickup window + notification. If `availableBooks === 0` → `waitlisted` + position shown + notification on promotion.
+- **Pickup window:** if the window expires without pickup → auto `no_show`, release copy to the waitlist, warn user (threshold → D2). Admin dropdown actions: **mark done / reschedule**. Needs a **pickup list view** ("picked and not" tags) — see Section 7.2.
+- **Due date & return:** loan duration **configurable** in Settings (default 14 days). Admin marks `returned` → `availableBooks + 1` → notify next waitlisted member that the book is free.
+- **Overdue:** auto **email + in-app alert** "borrowing duration is over". If waitlist non-empty → **request return**; else → **suggest extension**.
+- **Extension:** user requests → **auto-approve when the queue is empty**; else admin approves/refuses with a reason.
+
+**Verification tie-in:** unverified users can request/waitlist but **cannot reach `picked`**; admin is alerted to verify before pickup.
+
+**Cancelability:** every operation (loan req, extension, registration, pickup) defines explicit cancel rules in Section 10 (open decisions).
+
+---
+
+## 5. Notifications (new subsystem)
+
+**Channels:** **SSE** for in-app (bell + dropdown, the approved design) and **email** via nodemailer (existing; provider to be set later). Per-channel opt-in in Profile → Settings.
+
+**Delivery model (locked):** events write a `notifications` collection (relation → user, `seen`, `type`, link, `emailSent` flag); an SSE push is delivered to the connected session on create; email is triggered from the same hook.
+
+**Bell UX:** bell in navbar (desktop) + mobile menu; hidden for Visitor. Unread badge count. Click → dropdown (recent 10) → "view all" page with filters (all/unread by type).
+
+**Trigger matrix:**
+
+| Trigger | Audience | When |
+|---|---|---|
+| Book free/waitlist available | Waitlisted user | Copy released |
+| Request response (book) | Requesting user | approved/refused |
+| Request response (activity) | Registered user | registration accepted/rejected/quota |
+| Loan period end / near-end | Active borrower | Due date approaching (onboarding helper + alert) |
+| Overdue escalation | Borrower | past due |
+| New activity | All users | activity created/published |
+| New article | All users | article created/published |
+| Pickup reminder/no-show warning | Borrowers | pickup window |
+| Admin notifications | Admin panel | severe overdues, pending queues, request arrivals, new user count |
+
+**Email policy (proposed defaults):**
+- **Mandatory email:** request responses (book), extension results, overdue, pickup reminders, no-show warnings, verification result.
+- **Bulk audiences** ("new activity"/"new article" to all users): in-app + **digest email** (daily/on-demand).
+- **Opt-in defaults:** in-app ON; transactional email ON by default; bulk email OFF unless opted-in.
+
+**Admin bell (proposed):** severe overdues, new pending borrow/extension/verification requests, pickups due today, new users, new reviews.
+
+---
+
+## 6. Features — User View
+
+Each item tagged **New / Extend / Polish**, with data impact.
+
+### 6.1 Landing *(Polish)*
+- Hero video **auto-plays forcibly** (muted, playsinline, autoplay, no-poster-gate).
+
+### 6.2 Notifications *(New)*
+- Bell + dropdown in navbar (Visitor → hide bell). Unread badge. Tap → destination route (loan, article, activity). Mark-as-read.
+- List page with filters (all/unread by type). See Section 5.
+
+### 6.3 My Activities *(Extend)*
+- Registered activities (exists in profile) + **calendar view** (New): activities mapped to dates (existing `schedules`).
+- **Dashboard calendar** (New): month grid combining activities + loan due dates (Section 6.4).
+
+### 6.4 Dashboard (user) *(New)*
+- Calendar of activities & due returns.
+- Book request status cards.
+- Activity log of **own** actions (light; full user log is v2).
+
+### 6.5 Loans *(New + Extend)*
+- **My loans** — currently borrowed list (exists; extend with state machine badges, pickup window, return due).
+- **Extension request** (New) — button when eligible; per Section 4.
+- **Waitlist** (New) — join if no free copy; show position; auto-promotion to request on availability.
+- **Borrow-limit indicator** — show remaining concurrent loans.
+- **Verification notice** — checkout blocked with a clear "needs verification" state until verified.
+
+### 6.6 Books *(Extend)*
+- **Request a non-existing book** (New) — form → new collection `book-requests`; surfaced to admin queue + "requested books" analytics.
+- **Add review** (exists; polish to design).
+
+### 6.7 Articles *(Extend)*
+- **Info dialog** (New) — overlay with metadata (publisher, type, cover, date) on list items.
+- **Reading-feedback popup** (New) — after "finishing reading" (define trigger in §10): like/dislike + optional comment (feeds analytics).
+- **Add review** (New) — article reviews category (see §10 conflict with feedback).
+- **Sections refinement** (Polish): fill/stroke styles + indentation per approved design.
+- **Bookmark articles** (New) — mirrors book favorites; appears in Profile → bookmarks.
+
+### 6.8 Activities *(Extend)*
+- Registration exists. **Document all flows** in §8 (register → confirm → reminder → attended → feedback).
+- Post-event **positive/negative feedback** (New) — small rating on detail after end date (feeds analytics).
+- Capacity indicator exposed (participant counts already tracked).
+
+### 6.9 Profile / Settings *(Extend + New)*
+- **Bookmarks** tab: books (exists as favorites) + articles (new).
+- **Notifications** tab: per-channel opt-in for the matrix in §5.
+- **Info** tab: personal data (existing account tab).
+- **Security** tab: change password (exists). **Password reset + 2FA deferred.**
+
+### 6.10 Onboarding / Helpers *(New)*
+- **First onboarding** — books + loan flow: 3–4 step intro on first library visit (dismissible, remembers seen).
+- **Contextual helper** — when a borrowed book's return is near: explain extension possibility.
+- **Waitlist helper** — explain waitlist & auto-promotion when requesting an unavailable book.
+
+---
+
+## 7. Features — Admin View (full panel)
+
+### 7.1 Dashboard *(New)*
+- Pending-request card (borrowing / extension / account verification / severe overdues).
+- **Today's pickups** list (user, book, code, day+hour) with dropdown: mark done / reschedule.
+- Latest reviews (top 3).
+- Activities calendar (1).
+- Today's activities log (3).
+- New-users count (recent registration).
+
+### 7.2 Loans *(New)*
+- Request queue (if no copy → waitlist indicator).
+- Extension-request queue.
+- **KPIs:** total loans, this month, exceeded-time count, extension requests.
+- Table: user, book, date, book status, quantity.
+- **Duplicate-loan check:** alert before approving — "user has unreturned books" (2 actions: accept / refuse with reason).
+- **Manual add** borrowing/extension dialog — **search by name/email (no matricule)**, book search, take/return dates.
+- **Pickup view:** "picked / not" tags; used for no-show signalling.
+
+### 7.3 Users *(New)*
+- KPI of user books (low priority).
+- User/staff table; row actions (dropdown or right-click menu).
+- Previous borrowings per user (status: returned / not returned).
+- Reviews per user (low).
+- Extension requests with **due-check logic** (queue empty → available; else refuse).
+- **Certificate** in profile info (stored in v1 — D13 ✓) + **verification state management**.
+
+### 7.4 Books *(Extend)*
+- Consistent sidebar elements (already designed).
+- Books list/CRUD; duplicate handling via multi-copy model (§9 concern) — multiple copies share the same book id.
+
+### 7.5 Articles *(New)*
+- **KPIs:** total, this month, views, interactions.
+- **Grid + list views** (list: title, description, type, date, publisher).
+- **CRUD** — any admin can edit (no publisher ownership rule).
+- Row dropdown: edit / delete / info (who, when, type, cover) / share / copy.
+- Article reading page (exists; invoke from admin).
+
+### 7.6 Activities *(New)*
+- **KPIs:** total, current (open), enrolled, upcoming.
+- Types: events vs "all-time" activities.
+- List + dropdown actions; **add activity dialog**.
+- **Calendar.**
+- **Horizontal snippet-card layout** (not article-like).
+- Activity info: name, description, image, date, who can participate, location, type, duration, state.
+- Detail page (exists).
+
+### 7.7 Logs *(New)*
+- Two partitions: **admins** (v1) + **users** (v2).
+- Required info: user, timestamp, action, date.
+- Filters: multi-user, date (value/range), action type (via filter dialog).
+
+### 7.8 Analytics *(New)*
+Computed **from the DB** (Postgres aggregation) — no external service.
+- Article insights: reads, feedback (likes/dislikes). *(last 2)*
+- Activity insights: registrations, positive/negative feedback. *(last 2)*
+- Most-borrowed books; requested books; article with most interactions; categories most read; borrowings **monthly evolution**; days & hours where borrowings increase; days & hours when pickups increase.
+
+### 7.9 Settings *(New)*
+- Admin info (name, email, pfp).
+- **Security**: change password, **2FA deferred**, logged-in devices/link device — **must verify identity first** (edit/manage as pages; verifications as dialogs).
+- **Notifications**: toggles for logs, borrowing/extension/user requests, reviews, severe overdues, daily activities.
+- **Loan configuration (New):** default loan duration + **borrow limit** (max concurrent loans).
+- **Keyboard shortcuts** (add new borrowing, etc.).
+
+### 7.10 Reviews *(New)*
+- Two categories: **book reviews** and **article reviews**.
+- Admin actions: delete / copy.
+- KPIs (counts, avg per category).
+
+---
+
+## 8. Activities — Complete Flows (documented for both views)
+
+1. **Browse → detail** (info: name, desc, image, dates, participants, location, type, duration, state).
+2. **Register** (gates: open, deadline, max capacity) → confirmation notification.
+3. **Pre-event**: reminder notification (schedule-based).
+4. **Event day**: `attended` marked by admin/user.
+5. **Post-event**: feedback (positive/negative) + auto-completion.
+6. **Branch**: overflow capacity → waitlist/notification when spot opens (matches book waitlist pattern — decision in §10).
+7. **Cancel**: registration cancellation rules (before deadline) + quota re-open.
+
+---
+
+## 9. Engineering Concern — Multi-Copy Books
+
+- One `Book` doc with `totalBooks/availableBooks` counters (current model) satisfies "same book, one id".
+- Copies aren't individually tracked in v1 (proposed — D7). Consequences for pickups ("book code"), no-show release, and on-site (v2) → generate a copy code at pickup time; revisit per-copy records only if design requires distinct copy codes.
+
+---
+
+## 10. Open Decisions
+
+**Resolved (✅):**
+
+| ID | Decision | Resolution |
+|---|---|---|
+| D9 | Notification delivery | **SSE** + sync email hook (provider later) |
+| D12 | Admin manual add | Search by **name/email** (no matricule field) |
+| D13 | User certificate | **Store in v1**; display in admin Users → profile info |
+| — | Extension auto | **Auto-approve when queue empty** |
+| — | Loan duration | **Configurable** (default 14 days) in Settings |
+| — | Borrow limit | **Configurable** max concurrent loans |
+| — | Publisher role | **None** — all admins edit all content |
+| — | Deployment | **Docker/VPS** |
+| — | Scale | **Thousands** of users |
+| — | Language | **Arabic-only** v1 |
+| — | Admin panel location | Stays under **/admin** |
+| — | Password reset / 2FA | **Deferred** |
+
+**Remaining (must be resolved before build):**
+
+1. **D1 — Pickup window behavior**: duration (e.g., 24h/48h/72h), tolerance, reschedule limits, and exactly when `no_show` triggers.
+2. **D2 — No-show threshold**: 2 warnings → restriction scope (blocks borrows? days? configurable?).
+3. **D3 — "Finishing reading"** trigger for article feedback popup.
+4. **D4 — Article reviews vs like/dislike feedback** — are they the same? (Conflicts between §6.7 and §7.8.)
+5. **D5 — Activity overflow** — waitlist or plain "full" refusal?
+6. **D6 — Extension policy**: max extensions, max total duration, when eligible (X days before due).
+7. **D7 — Multi-copy model**: counters vs per-copy records (affects "book code" in pickups).
+8. **D8 — Cancelability rules** per operation type.
+9. **D10 — 2FA** in admin settings: deferred (confirmed) — revisit post-v1.
+10. **D11 — Book-request lifecycle**: confirm `book-requests` collection; submitted → reviewed → procured/refused; notifications on each transition.
+11. **Email provider** — to be set later.
+12. **Borrow-limit default value** (proposal: 3 concurrent loans).
+
+---
+
+## 11. Suggested v1 Priority
+
+**P0 (foundation):** notification subsystem (SSE), loan state machine, multi-copy model, book-requests.
+**P1:** user waitlist + extension + my-loans, dashboards/calendars, article bookmarks+feedback, onboarding.
+**P2 (admin):** loans queue + pickups + KPIs, articles/activities CRUD + analytics, logs, settings, reviews.
+**P3 (polish):** landing autoplay, sections refinement, cross-cutting empty states/skeletons/confirmation-alerts.
+
+---
+
+## 12. Tech Stack & Architecture
+
+### 12.1 Architecture
+- **Monolith**: one Next.js (App Router) process hosts the public site **and** Payload CMS in-process. REST at `/api/*`, GraphQL at `/api/graphql`, admin at **/admin** (same app).
+- **Rendering split**: public read pages = Server Components + `getPayload`; interactive pages = Client Components + TanStack Query (cookie auth).
+- **Auth**: Payload JWT cookie, `role` in JWT, role-based redirect + server-side re-checks. **Google OAuth** = only social login. **Password reset deferred.** Visitor→user gating: borrow/bookmark/register/review require sign-in (visitor is redirected, never blocked from browsing).
+
+### 12.2 Stack table
+| Layer | Choice |
+|---|---|
+| Framework | Next.js (App Router) |
+| Runtime | Node (Docker) |
+| Language | TypeScript |
+| CMS | Payload CMS (in-process) |
+| Database | PostgreSQL 17 (local Supabase CLI / remote) |
+| Storage | Supabase S3 |
+| Data fetching | TanStack Query v5 (client) |
+| State | Zustand |
+| UI | Tailwind + shadcn/ui + Base-UI |
+| Animation | motion |
+| Forms | react-hook-form + zod |
+| Toasts | sonner |
+| Email | nodemailer (provider later) |
+| Auth | Payload auth + Google OAuth |
+| Fonts | Local Arabic fonts |
+| Package manager | pnpm |
+| Lint | ESLint |
+| Local Supabase | Supabase CLI |
+
+### 12.3 Environments
+- **dev** `.env.local` → local Supabase (DB :54322, S3 :54321, Studio :54323, Inbucket :54324 for email).
+- **preview/prod** `.env` → remote Supabase; `NODE_ENV` switches CSP/headers.
+
+### 12.4 Data model
+**Current:** users, media, books, activities, articles, loans, reviews, activity-registrations, book-favorites.
+**Planned:** notifications, book-requests, waitlist, loan-extensions, logs, analytics-events, article bookmarks, article/activity feedback.
+**Access control:** role-based matrix — visitor (read published), user (own data + interactions), admin (full). Field-level guards on roles.
+
+### 12.5 Deployment
+**Docker/VPS** (multi-stage standalone image; Vercel not targeted). Build = `payload migrate && next build`.
+
+### 12.6 Logs & Analytics
+- **Logs**: Payload `logs` collection — `actor` (user/admin), `action` (enum), `target` (book/loan/article/activity), `timestamp`, `metadata`. Admin view with multi-user / date-range / action-type filters. Admin logs v1; user logs v2.
+- **Analytics**: computed **from the DB** (no external service) via aggregation over existing collections + a lightweight `analytics-events` collection (article reads, article feedback, activity feedback, views). KPIs = Postgres `GROUP BY` (monthly evolution via `date_trunc`, peak days/hours).
+- **External monitoring**: propose (Sentry for errors + self-hosted Umami/Plausible for traffic, or none) — to be discussed with the team later.
+
+### 12.7 Notifications architecture
+- `notifications` collection (user, type, seen, link, emailSent) + **SSE** for real-time in-app delivery + nodemailer for email (provider TBD). Bulk audiences → digest option.
+
+### 12.8 Scale & performance
+- Target **thousands** of users. Notes: indexed/filtered queries, pagination on all listings, `select`/`maxDepth` limits, caching of public read queries; SSE connection pooling.
+
+### 12.9 Language
+- **Arabic-only** for v1; string/format conventions kept centralized for future locale support.


### PR DESCRIPTION
## Summary

Unify the frontend page layouts across library, articles, activities, about-us,
and contact-us pages, and redesign the activity cards to match the Figma spec.

## Changes

### Layout unification
- `components/layouts/index.tsx`: shared layout now uses a
  `flex min-h-screen flex-col` structure with a centered `max-w-7xl` content
  container (`flex-1`), keeping the footer pinned at the bottom. Added optional
  `containerClassName` prop for per-page customization.
- `Navbar`: logo swapped to the horizontal `logo-horizontal.svg` variant.

### Pages
- **Library & Articles**: now reuse the landing `BookCard` / `BlogArticleCard`
  components (with skeletons) on a responsive grid; unified section titles.
- **About-us & Contact-us**: removed hero/entry motion animations (plain
  headings), aligned to `max-w-7xl`, footer-pinning layout, tightened spacing.
- **Activities**: unified title styling.

### Activity card redesign (Figma-based)
- New `ActivityCard` with RTL layout — image on the right (`border-l`),
  content on the left, `h-[390px]` rounded-2xl card.
- Type tag chip, `font-khalid` title, 2×2 details grid (location, start date,
  schedule count, audience), and a status badge (`قائم` / `مكتمل`).
- Interactive footer: like, comment, share (native share with clipboard
  fallback), and bookmark toggles. Card links to `/activities/{id}`.
- `ActivitySkeleton` rewritten to mirror the new card structure.

### Docs
- Added `docs/PRD.md` (v2) and `docs/PRD-open-decisions.md` with all
  resolved open decisions.

## Verification
- `pnpm typecheck` passes
- `/library`, `/articles`, `/activities`, `/about-us`, `/contact-us` all return 200

## Note
This branch is based directly on `dev` and contains only the 2 commits above.