### PR TITLE
feat(user-portal): dashboard, latest-updates, scroll fix, theme scoping

### DIFF
--- a/actions/profile/dashboard.ts
+++ b/actions/profile/dashboard.ts
@@ -14,7 +14,7 @@ export async function getProfileDashboardData() {
     overrideAccess: false,
   })
 
-  const [favorites, registrations, loans] = await Promise.all([
+  const [favorites, registrations, loans, articles] = await Promise.all([
     ctx.payload.find({
       collection: 'book-favorites',
       where: { user: { equals: ctx.user.id } },
@@ -42,6 +42,14 @@ export async function getProfileDashboardData() {
       req: ctx.req,
       overrideAccess: false,
     }),
+    ctx.payload.find({
+      collection: 'articles',
+      depth: 1,
+      limit: 3,
+      sort: '-createdAt',
+      req: ctx.req,
+      overrideAccess: false,
+    }),
   ])
 
   return {
@@ -49,5 +57,6 @@ export async function getProfileDashboardData() {
     favorites: favorites.docs,
     registrations: registrations.docs,
     loans: loans.docs,
+    articles: articles.docs,
   }
 }

--- a/actions/profile/latest-updates.ts
+++ b/actions/profile/latest-updates.ts
@@ -1,0 +1,32 @@
+'use server'
+
+import { getPayloadWithUser } from '@/lib/auth'
+
+export async function getLatestUpdates() {
+  const ctx = await getPayloadWithUser()
+  if (!ctx) return null
+
+  const [articles, activities] = await Promise.all([
+    ctx.payload.find({
+      collection: 'articles',
+      depth: 1,
+      limit: 5,
+      sort: '-createdAt',
+      req: ctx.req,
+      overrideAccess: false,
+    }),
+    ctx.payload.find({
+      collection: 'activities',
+      depth: 1,
+      limit: 4,
+      sort: '-createdAt',
+      req: ctx.req,
+      overrideAccess: false,
+    }),
+  ])
+
+  return {
+    articles: articles.docs,
+    activities: activities.docs,
+  }
+}

--- a/app/member-portal/UserPage.tsx
+++ b/app/member-portal/UserPage.tsx
@@ -10,7 +10,7 @@ const UserPage: React.FC<UserPageProps> = ({ title, description, children }) => 
   return (
     <div className="flex min-h-0 h-full flex-col">
       <UserPageHeader title={title} />
-      <div className="flex-1 min-h-0 space-y-6 overflow-y-auto rounded-2xl border border-tabs-active bg-background p-3 sm:p-4 lg:p-5">
+      <div className="flex-1 min-h-0 space-y-6 overflow-y-auto rounded-2xl border border-tabs-active bg-background p-3 sm:p-4 lg:p-5 [contain:layout]">
         {description ? (
           <p className="mb-4 text-muted-foreground">{description}</p>
         ) : null}

--- a/app/member-portal/activity-log/page.tsx
+++ b/app/member-portal/activity-log/page.tsx
@@ -3,7 +3,7 @@ import { Card } from '@/components/ui/card'
 
 export default function ActivityLogPage() {
   return (
-    <UserPage title="سجل الأحداث" description="سجل نشاطك وحركتك داخل بوابة العضو">
+    <UserPage title="سجل الأحداث" description="سجل نشاطك وحركتك داخل بوابة المستخدم">
       <Card className="p-10 text-center text-muted-foreground">هذا القسم قيد التطوير.</Card>
     </UserPage>
   )

--- a/app/member-portal/dashboard/_components/ArticlesPreview.tsx
+++ b/app/member-portal/dashboard/_components/ArticlesPreview.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import Link from 'next/link'
+import Image from 'next/image'
+import { format } from 'date-fns'
+import { arDZ } from 'date-fns/locale'
+import type { Article, Media } from '@/payload-types'
+import { getImageUrl } from '@/utils/image-utils'
+import { articleTypesConfigArray } from '@/utils/constants/articles'
+
+interface ArticlesPreviewProps {
+  articles: Article[]
+}
+
+const ArticlesPreview: React.FC<ArticlesPreviewProps> = ({ articles }) => {
+  return (
+    <section className="rounded-2xl border border-border bg-card">
+      <header className="flex items-center justify-between gap-2 border-b border-border px-4 py-3">
+        <h2 className="text-sm font-semibold text-card-foreground">آخر المقالات</h2>
+        <Link href="/user/articles" className="text-xs text-primary-300 hover:underline">
+          عرض الكل
+        </Link>
+      </header>
+
+      {articles.length === 0 ? (
+        <p className="px-4 py-10 text-center text-sm text-muted-foreground">لا توجد مقالات بعد.</p>
+      ) : (
+        <ul className="divide-y divide-border">
+          {articles.map((article) => {
+            const cover = article.image as Media | undefined
+            const published = article.publishDate || article.createdAt
+            const typeLabel =
+              articleTypesConfigArray.find((config) => config.value === article.type)?.label ?? 'مقال'
+
+            return (
+              <li key={article.id}>
+                <Link
+                  href={`/user/articles/${article.id}`}
+                  className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/40"
+                >
+                  <Image
+                    src={getImageUrl(cover?.url, '/static/images/quran.png')}
+                    alt={article.title}
+                    width={40}
+                    height={40}
+                    className="size-10 shrink-0 rounded-md border border-border object-cover"
+                  />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium text-card-foreground">
+                      {article.title}
+                    </p>
+                    <p className="truncate text-xs text-muted-foreground">
+                      {format(new Date(published), 'd MMM yyyy', { locale: arDZ })}
+                    </p>
+                  </div>
+                  <span className="inline-flex h-6 shrink-0 items-center rounded-full bg-background-2 px-2.5 text-xs font-medium text-card-foreground">
+                    {typeLabel}
+                  </span>
+                </Link>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </section>
+  )
+}
+
+export default ArticlesPreview

--- a/app/member-portal/dashboard/_components/LoansPreview.tsx
+++ b/app/member-portal/dashboard/_components/LoansPreview.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import Link from 'next/link'
+import Image from 'next/image'
+import { format } from 'date-fns'
+import { arDZ } from 'date-fns/locale'
+import type { Book, Loan, Media } from '@/payload-types'
+import { cn } from '@/lib/utils'
+import { getImageUrl } from '@/utils/image-utils'
+import LoanStatusBadge from '../../my-loans/_components/LoanStatusBadge'
+
+interface LoansPreviewProps {
+  loans: Loan[]
+  className?: string
+}
+
+const LoansPreview: React.FC<LoansPreviewProps> = ({ loans, className }) => {
+  return (
+    <section className={cn('rounded-2xl border border-border bg-card', className)}>
+      <header className="flex items-center justify-between gap-2 border-b border-border px-4 py-3">
+        <h2 className="text-sm font-semibold text-card-foreground">أحدث الإعارات</h2>
+        <Link href="/user/my-loans" className="text-xs text-primary-300 hover:underline">
+          عرض الكل
+        </Link>
+      </header>
+
+      {loans.length === 0 ? (
+        <p className="px-4 py-10 text-center text-sm text-muted-foreground">لا توجد إعارات حالية.</p>
+      ) : (
+        <ul className="divide-y divide-border">
+          {loans.slice(0, 4).map((loan) => {
+            const book = loan.book as Book | undefined
+            const cover = book?.image as Media | undefined
+            const due = loan.dueDate ? format(new Date(loan.dueDate), 'd MMM yyyy', { locale: arDZ }) : null
+
+            return (
+              <li key={loan.id}>
+                <Link
+                  href={`/user/library/book/${book?.id ?? ''}`}
+                  className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/40"
+                >
+                  <Image
+                    src={getImageUrl(cover?.url, '/static/images/quran.png')}
+                    alt={book?.title || 'صورة الكتاب'}
+                    width={40}
+                    height={40}
+                    className="size-10 shrink-0 rounded-md border border-border object-cover"
+                  />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium text-card-foreground">
+                      {book?.title || '—'}
+                    </p>
+                    <p className="truncate text-xs text-muted-foreground">{book?.author}</p>
+                  </div>
+                  <div className="flex shrink-0 flex-col items-end gap-1">
+                    <LoanStatusBadge loan={loan} />
+                    {due ? <span className="text-xs text-muted-foreground">{due}</span> : null}
+                  </div>
+                </Link>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </section>
+  )
+}
+
+export default LoansPreview

--- a/app/member-portal/dashboard/_components/RegistrationsPreview.tsx
+++ b/app/member-portal/dashboard/_components/RegistrationsPreview.tsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import Link from 'next/link'
+import Image from 'next/image'
+import { format } from 'date-fns'
+import { arDZ } from 'date-fns/locale'
+import type { Activity, ActivityRegistration, Media } from '@/payload-types'
+import { getImageUrl } from '@/utils/image-utils'
+import RegistrationStatusBadge from '../../my-registrations/_components/RegistrationStatusBadge'
+
+interface RegistrationsPreviewProps {
+  registrations: ActivityRegistration[]
+}
+
+const RegistrationsPreview: React.FC<RegistrationsPreviewProps> = ({ registrations }) => {
+  return (
+    <section className="rounded-2xl border border-border bg-card">
+      <header className="flex items-center justify-between gap-2 border-b border-border px-4 py-3">
+        <h2 className="text-sm font-semibold text-card-foreground">تسجيلاتي القادمة</h2>
+        <Link href="/user/my-registrations" className="text-xs text-primary-300 hover:underline">
+          عرض الكل
+        </Link>
+      </header>
+
+      {registrations.length === 0 ? (
+        <p className="px-4 py-10 text-center text-sm text-muted-foreground">
+          لا توجد تسجيلات قادمة.
+        </p>
+      ) : (
+        <ul className="divide-y divide-border">
+          {registrations.slice(0, 3).map((registration) => {
+            const activity = registration.activity as Activity | undefined
+            const cover = activity?.image as Media | undefined
+            const start = activity?.startDate ? new Date(activity.startDate) : null
+
+            return (
+              <li key={registration.id}>
+                <Link
+                  href={`/user/activities/${activity?.id ?? ''}`}
+                  className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/40"
+                >
+                  <Image
+                    src={getImageUrl(cover?.url, '/static/images/quran.png')}
+                    alt={activity?.title || 'صورة النشاط'}
+                    width={40}
+                    height={40}
+                    className="size-10 shrink-0 rounded-md border border-border object-cover"
+                  />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-sm font-medium text-card-foreground">
+                      {activity?.title || 'نشاط'}
+                    </p>
+                    <p className="truncate text-xs text-muted-foreground">
+                      {activity?.location || '—'}
+                    </p>
+                  </div>
+                  <div className="flex shrink-0 flex-col items-end gap-1">
+                    <RegistrationStatusBadge registration={registration} />
+                    <span className="text-xs text-muted-foreground">
+                      {start ? format(start, 'd MMM yyyy', { locale: arDZ }) : 'غير محدد'}
+                    </span>
+                  </div>
+                </Link>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </section>
+  )
+}
+
+export default RegistrationsPreview

--- a/app/member-portal/dashboard/_components/StatCard.tsx
+++ b/app/member-portal/dashboard/_components/StatCard.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import Link from 'next/link'
+import type { LucideIcon } from 'lucide-react'
+
+interface StatCardProps {
+  label: string
+  value: number
+  icon: LucideIcon
+  href: string
+}
+
+const StatCard: React.FC<StatCardProps> = ({ label, value, icon: Icon, href }) => {
+  return (
+    <Link
+      href={href}
+      className="flex items-center justify-between gap-3 rounded-2xl border border-border bg-card p-4 transition-colors hover:border-tabs-active"
+    >
+      <div className="min-w-0">
+        <div className="text-2xl font-bold text-card-foreground">{value}</div>
+        <div className="mt-0.5 truncate text-sm text-muted-foreground">{label}</div>
+      </div>
+      <div className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-background-2 text-primary-300">
+        <Icon className="size-5" aria-hidden />
+      </div>
+    </Link>
+  )
+}
+
+export default StatCard

--- a/app/member-portal/dashboard/loading.tsx
+++ b/app/member-portal/dashboard/loading.tsx
@@ -1,0 +1,22 @@
+import { Skeleton } from '@/components/ui/skeleton'
+import UserPage from '../UserPage'
+
+export default function MemberDashboardLoading() {
+  return (
+    <UserPage title="لوحة التحكم">
+      <Skeleton className="h-24 rounded-2xl" />
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <Skeleton key={index} className="h-24 rounded-2xl" />
+        ))}
+      </div>
+      <div className="grid gap-6 lg:grid-cols-3">
+        <Skeleton className="h-64 rounded-2xl lg:col-span-2" />
+        <div className="flex flex-col gap-6">
+          <Skeleton className="h-44 rounded-2xl" />
+          <Skeleton className="h-44 rounded-2xl" />
+        </div>
+      </div>
+    </UserPage>
+  )
+}

--- a/app/member-portal/dashboard/page.tsx
+++ b/app/member-portal/dashboard/page.tsx
@@ -1,18 +1,89 @@
-import { Construction } from 'lucide-react'
+import { format } from 'date-fns'
+import { arDZ } from 'date-fns/locale'
+import { Bookmark, CalendarCheck, LibraryBig, Newspaper } from 'lucide-react'
+import type { Activity, ActivityRegistration } from '@/payload-types'
+import { getProfileDashboardData } from '@/actions/profile/dashboard'
 import UserPage from '../UserPage'
+import StatCard from './_components/StatCard'
+import LoansPreview from './_components/LoansPreview'
+import RegistrationsPreview from './_components/RegistrationsPreview'
+import ArticlesPreview from './_components/ArticlesPreview'
 
-export default function MemberDashboardPage() {
+function isUpcomingRegistration(registration: ActivityRegistration): boolean {
+  if (registration.attended) return false
+  const activity = registration.activity as Activity | undefined
+  const start = activity?.startDate
+    ? new Date(activity.startDate).getTime()
+    : Number.POSITIVE_INFINITY
+  return start >= Date.now()
+}
+
+export default async function MemberDashboardPage() {
+  const data = await getProfileDashboardData()
+  if (!data) {
+    return (
+      <UserPage title="لوحة التحكم">
+        <div className="text-muted-foreground">لا يمكن تحميل البيانات.</div>
+      </UserPage>
+    )
+  }
+
+  const activeLoans = data.loans.filter(
+    (loan) => loan.status === 'pending' || loan.status === 'approved' || loan.status === 'overdue',
+  )
+  const upcomingRegistrations = data.registrations.filter(isUpcomingRegistration)
+
+  const stats = [
+    {
+      label: 'إعاراتي',
+      value: activeLoans.length,
+      icon: LibraryBig,
+      href: '/user/my-loans',
+    },
+    {
+      label: 'تسجيلاتي',
+      value: upcomingRegistrations.length,
+      icon: CalendarCheck,
+      href: '/user/my-registrations',
+    },
+    {
+      label: 'مفضّلتي',
+      value: data.favorites.length,
+      icon: Bookmark,
+      href: '/user/bookmarks',
+    },
+    {
+      label: 'المقالات',
+      value: data.articles.length,
+      icon: Newspaper,
+      href: '/user/articles',
+    },
+  ]
+
   return (
     <UserPage title="لوحة التحكم">
-      <section className="flex flex-col items-center justify-center gap-4 rounded-2xl border border-dashed border-tabs-active bg-card px-6 py-20 text-center">
-        <div className="flex size-16 items-center justify-center rounded-full bg-primary-200/40">
-          <Construction className="size-8 text-primary-300" aria-hidden />
-        </div>
-        <h2 className="text-xl font-bold text-[#243245] dark:text-card-foreground">لوحة التحكم</h2>
-        <p className="max-w-md text-sm text-muted-foreground">
-          هذه الصفحة قيد التطوير، سيتم إضافة ملخص أنشطتك وإعاراتك وتسجيلاتك هنا قريباً.
+      <div className="rounded-2xl border border-border bg-card p-4 sm:p-5">
+        <h2 className="text-lg font-semibold text-card-foreground">
+          مرحباً، {data.user.fullName || 'عزيزي العضو'}
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {format(new Date(), 'EEEE d MMMM yyyy', { locale: arDZ })}
         </p>
-      </section>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4 lg:grid-cols-4">
+        {stats.map((stat) => (
+          <StatCard key={stat.href} {...stat} />
+        ))}
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        <LoansPreview loans={activeLoans} className="lg:col-span-2" />
+        <div className="flex flex-col gap-6">
+          <RegistrationsPreview registrations={upcomingRegistrations} />
+          <ArticlesPreview articles={data.articles} />
+        </div>
+      </div>
     </UserPage>
   )
 }

--- a/app/member-portal/latest-updates/page.tsx
+++ b/app/member-portal/latest-updates/page.tsx
@@ -1,10 +1,137 @@
+import React from 'react'
+import Link from 'next/link'
+import Image from 'next/image'
+import { format } from 'date-fns'
+import { arDZ } from 'date-fns/locale'
 import UserPage from '@/app/member-portal/UserPage'
 import { Card } from '@/components/ui/card'
+import { getLatestUpdates } from '@/actions/profile/latest-updates'
+import { getImageUrl } from '@/utils/image-utils'
+import { activitiesTypesConfig } from '@/utils/constants/activities'
+import { articleTypesConfigArray } from '@/utils/constants/articles'
+import type { Article, Activity, Media } from '@/payload-types'
 
-export default function LatestUpdatesPage() {
+const formatDate = (value: string | undefined) =>
+  value ? format(new Date(value), 'd MMM yyyy', { locale: arDZ }) : 'غير محدد'
+
+const ArticleRow: React.FC<{ article: Article }> = ({ article }) => {
+  const cover = article.image as Media | undefined
+  const published = article.publishDate || article.createdAt
+  const typeLabel =
+    articleTypesConfigArray.find((config) => config.value === article.type)?.label ?? 'مقال'
+
+  return (
+    <li>
+      <Link
+        href={`/user/articles/${article.id}`}
+        className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/40"
+      >
+        <Image
+          src={getImageUrl(cover?.url, '/static/images/quran.png')}
+          alt={article.title}
+          width={48}
+          height={48}
+          className="size-12 shrink-0 rounded-md border border-border object-cover"
+        />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-card-foreground">{article.title}</p>
+          <p className="mt-0.5 truncate text-xs text-muted-foreground">
+            {article.author} • {formatDate(published)}
+          </p>
+        </div>
+        <span className="inline-flex h-6 shrink-0 items-center rounded-full bg-background-2 px-2.5 text-xs font-medium text-card-foreground">
+          {typeLabel}
+        </span>
+      </Link>
+    </li>
+  )
+}
+
+const ActivityRow: React.FC<{ activity: Activity }> = ({ activity }) => {
+  const cover = activity.image as Media | undefined
+  const typeLabel = activitiesTypesConfig[activity.type] ?? 'نشاط'
+
+  return (
+    <li>
+      <Link
+        href={`/user/activities/${activity.id}`}
+        className="flex items-center gap-3 px-4 py-3 transition-colors hover:bg-muted/40"
+      >
+        <Image
+          src={getImageUrl(cover?.url, '/static/images/quran.png')}
+          alt={activity.title}
+          width={48}
+          height={48}
+          className="size-12 shrink-0 rounded-md border border-border object-cover"
+        />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-card-foreground">{activity.title}</p>
+          <p className="mt-0.5 truncate text-xs text-muted-foreground">
+            {activity.location || 'في مسجد الجامعة'} • {formatDate(activity.startDate)}
+          </p>
+        </div>
+        <span className="inline-flex h-6 shrink-0 items-center rounded-full bg-background-2 px-2.5 text-xs font-medium text-card-foreground">
+          {typeLabel}
+        </span>
+      </Link>
+    </li>
+  )
+}
+
+const LatestUpdatesPage: React.FC = async () => {
+  const data = await getLatestUpdates()
+
   return (
     <UserPage title="آخر التحديثات" description="آخر أخبار ومستجدات المسجد">
-      <Card className="p-10 text-center text-muted-foreground">هذا القسم قيد التطوير.</Card>
+      {data ? (
+        <div className="space-y-6">
+          <section className="rounded-2xl border border-border bg-card">
+            <header className="flex items-center justify-between gap-2 border-b border-border px-4 py-3">
+              <h2 className="text-sm font-semibold text-card-foreground">أحدث المقالات</h2>
+              <Link href="/user/articles" className="text-xs text-primary-300 hover:underline">
+                عرض الكل
+              </Link>
+            </header>
+            {data.articles.length === 0 ? (
+              <p className="px-4 py-10 text-center text-sm text-muted-foreground">
+                لا توجد مقالات بعد.
+              </p>
+            ) : (
+              <ul className="divide-y divide-border">
+                {data.articles.map((article) => (
+                  <ArticleRow key={article.id} article={article} />
+                ))}
+              </ul>
+            )}
+          </section>
+
+          <section className="rounded-2xl border border-border bg-card">
+            <header className="flex items-center justify-between gap-2 border-b border-border px-4 py-3">
+              <h2 className="text-sm font-semibold text-card-foreground">أنشطة جديدة</h2>
+              <Link href="/user/activities" className="text-xs text-primary-300 hover:underline">
+                عرض الكل
+              </Link>
+            </header>
+            {data.activities.length === 0 ? (
+              <p className="px-4 py-10 text-center text-sm text-muted-foreground">
+                لا توجد أنشطة جديدة بعد.
+              </p>
+            ) : (
+              <ul className="divide-y divide-border">
+                {data.activities.map((activity) => (
+                  <ActivityRow key={activity.id} activity={activity} />
+                ))}
+              </ul>
+            )}
+          </section>
+        </div>
+      ) : (
+        <Card className="p-10 text-center text-muted-foreground">
+          تعذّر تحميل آخر التحديثات.
+        </Card>
+      )}
     </UserPage>
   )
 }
+
+export default LatestUpdatesPage

--- a/app/member-portal/layout.tsx
+++ b/app/member-portal/layout.tsx
@@ -6,7 +6,7 @@ import { getAuthenticatedUser } from '@/lib/auth'
 import { getProfileDashboardData } from '@/actions/profile/dashboard'
 
 export const metadata: Metadata = {
-  title: 'بوابة العضو',
+  title: 'بوابة المستخدم',
   robots: { index: false, follow: false },
 }
 

--- a/components/layouts/user/UserSidebar.tsx
+++ b/components/layouts/user/UserSidebar.tsx
@@ -49,11 +49,11 @@ const SidebarShell: React.FC<UserSidebarProps> = ({ userName, userEmail, loansBa
         )}
       >
         <div className={cn('flex shrink-0 items-center', collapsed ? 'h-16 justify-center' : 'h-20 pe-2 ps-5')}>
-          <Link href="/user/dashboard" aria-label="بوابة العضو">
+          <Link href="/user/dashboard" aria-label="بوابة المستخدم">
             {collapsed ? (
               <Image
                 src="/static/images/logo-icon.svg"
-                alt="بوابة العضو"
+                alt="بوابة المستخدم"
                 width={32}
                 height={40}
                 className="h-9 w-auto"
@@ -61,7 +61,7 @@ const SidebarShell: React.FC<UserSidebarProps> = ({ userName, userEmail, loansBa
             ) : (
               <Image
                 src="/static/images/logo-horizontal.svg"
-                alt="بوابة العضو"
+                alt="بوابة المستخدم"
                 width={112}
                 height={44}
                 className="h-10 w-auto"
@@ -197,7 +197,7 @@ const MobileTopbar: React.FC = () => {
           </nav>
         </div>
         <span className="ms-auto shrink-0 text-sm font-bold font-dubai">
-          {current?.label ?? 'بوابة العضو'}
+          {current?.label ?? 'بوابة المستخدم'}
         </span>
       </div>
     </header>

--- a/components/root-html-shell.tsx
+++ b/components/root-html-shell.tsx
@@ -4,6 +4,7 @@ import Script from 'next/script'
 import localFont from 'next/font/local'
 import QueryClientProvider from '@/lib/providers/query-client.provider'
 import ThemeProvider from '@/components/theme-provider'
+import ThemeScopeGuard from '@/components/theme-scope-guard'
 import { Toaster } from '@/components/ui/sonner'
 
 const khalidArt = localFont({
@@ -92,12 +93,13 @@ const RootHtmlShell: React.FC<React.PropsWithChildren> = ({ children }) => {
           id="theme-init"
           strategy="beforeInteractive"
           dangerouslySetInnerHTML={{
-            __html: `(function(){try{var c=document.documentElement.classList;c.remove('light','dark');var t=localStorage.getItem('theme');var dark=t?t==='dark':window.matchMedia('(prefers-color-scheme: dark)').matches;if(dark){c.add('dark');}else{c.add('light');}document.documentElement.style.colorScheme=dark?'dark':'light';}catch(e){}})();`,
+            __html: `(function(){try{var c=document.documentElement.classList;c.remove('light','dark');var p=window.location.pathname;var portal=p==='/user'||p.indexOf('/user/')===0||p==='/member-portal'||p.indexOf('/member-portal/')===0;var admin=p==='/admin'||p.indexOf('/admin/')===0;var t=localStorage.getItem('theme');var dark=(portal||admin)?(t?t==='dark':window.matchMedia('(prefers-color-scheme: dark)').matches):false;c.add(dark?'dark':'light');document.documentElement.style.colorScheme=dark?'dark':'light';}catch(e){}})();`,
           }}
         />
       </head>
       <body suppressHydrationWarning>
         <ThemeProvider>
+          <ThemeScopeGuard />
           <Toaster richColors position="top-center" />
           <QueryClientProvider>{children}</QueryClientProvider>
         </ThemeProvider>

--- a/components/theme-scope-guard.tsx
+++ b/components/theme-scope-guard.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import React, { useEffect } from 'react'
+import { usePathname } from 'next/navigation'
+import { useTheme } from 'next-themes'
+
+const isPortalPath = (path: string) =>
+  path === '/user' ||
+  path.startsWith('/user/') ||
+  path === '/member-portal' ||
+  path.startsWith('/member-portal/')
+
+const isAdminPath = (path: string) => path === '/admin' || path.startsWith('/admin/')
+
+const applyThemeClasses = (wantDark: boolean) => {
+  const el = document.documentElement
+  el.classList.remove('light', 'dark')
+  el.classList.add(wantDark ? 'dark' : 'light')
+  el.style.colorScheme = wantDark ? 'dark' : 'light'
+}
+
+const ThemeScopeGuard: React.FC = () => {
+  const pathname = usePathname()
+  const { theme } = useTheme()
+
+  useEffect(() => {
+    const mql = window.matchMedia('(prefers-color-scheme: dark)')
+    // Visitors pages have no dark mode: always enforce light.
+    const visitor = !isPortalPath(pathname) && !isAdminPath(pathname)
+
+    const sync = () => {
+      const wantDark =
+        !visitor && (theme === 'dark' || (theme === 'system' && mql.matches))
+      applyThemeClasses(wantDark)
+    }
+
+    sync()
+    mql.addEventListener('change', sync)
+    return () => mql.removeEventListener('change', sync)
+  }, [pathname, theme])
+
+  return null
+}
+
+export default ThemeScopeGuard


### PR DESCRIPTION
## Changes

### Dashboard (`/user/dashboard`)
- Greeting header with user's name + today's date
- 4 stat cards: إعاراتي / تسجيلاتي / مفضّلتي / المقالات (linked to respective pages)
- Preview grid: active loans with status/due, upcoming registrations with location/date, recent articles with type/publish date
- Loading skeleton
- Server action `getProfileDashboardData` extended to fetch latest articles

### Latest Updates (`/user/latest-updates`)
- Replaced "قيد التطوير" stub with a real feed
- Two sections: أحدث المقالات (5 rows) + أنشطة جديدة (4 rows)
- Each row: cover image, title, metadata, type chip → links to detail pages
- New server action `getLatestUpdates`

### Theme scoping
- Pre-paint script in `root-html-shell.tsx` forces light mode on visitor routes, respects stored preference on portal/admin
- New `ThemeScopeGuard` client component re-applies theme on SPA soft navigation
- Portal renamed from "بوابة العضو" → "بوابة المستخدم" (6 occurrences)

### Scroll fix (`/user/activities`)
- Chrome leaked the content panel's scrollable overflow into the viewport scroller when content exceeded the viewport height, creating a full-page scrollbar alongside the panel's scrollbar
- Fixed by adding `[contain:layout]` to the shared `UserPage` scroll panel — isolates the panel's layout overflow so only the panel scrolls
- Verified across all portal pages (activities, dashboard, my-registrations, bookmarks, articles, settings)