### PR TITLE
Harden the auth flow: sessions, media access, redirects, Google login

### DIFF
--- a/actions/auth/login.ts
+++ b/actions/auth/login.ts
@@ -11,7 +11,7 @@ interface LoginResult {
 export const login = async (email: string, password: string): Promise<LoginResult> => {
   const payload = await getPayload({ config })
   try {
-    const { user, token } = await payload.login({
+    const { user, token, exp } = await payload.login({
       collection: 'users',
       data: {
         email,
@@ -19,7 +19,7 @@ export const login = async (email: string, password: string): Promise<LoginResul
       },
     })
     if (token) {
-      await setPayloadTokenCookie(token)
+      await setPayloadTokenCookie(token, exp)
     }
     return { user: user as User }
   } catch {

--- a/actions/auth/login.ts
+++ b/actions/auth/login.ts
@@ -6,7 +6,6 @@ import { setPayloadTokenCookie } from '@/lib/auth'
 
 interface LoginResult {
   user: User | undefined
-  token?: string
 }
 
 export const login = async (email: string, password: string): Promise<LoginResult> => {
@@ -22,7 +21,7 @@ export const login = async (email: string, password: string): Promise<LoginResul
     if (token) {
       await setPayloadTokenCookie(token)
     }
-    return { user: user as User, token }
+    return { user: user as User }
   } catch {
     return { user: undefined }
   }

--- a/actions/auth/logout.ts
+++ b/actions/auth/logout.ts
@@ -1,10 +1,21 @@
 'use server'
 import { cookies as nextCookies } from 'next/headers'
+import { logoutOperation } from 'payload'
+import { getPayloadWithUser } from '@/lib/auth'
 
-export const logout = async () => {
+export const logout = async (opts?: { allSessions?: boolean }) => {
+  const ctx = await getPayloadWithUser({ allowAdmin: true })
+
+  if (ctx) {
+    await logoutOperation({
+      allSessions: opts?.allSessions ?? false,
+      collection: ctx.payload.collections['users'],
+      req: ctx.req,
+    })
+  }
+
   const cookies = await nextCookies()
-  
   cookies.delete('payload-token')
-  
+
   return { ok: true }
 }

--- a/actions/auth/register.ts
+++ b/actions/auth/register.ts
@@ -7,7 +7,6 @@ import { AuthError } from '@/lib/auth-errors'
 
 interface RegisterResult {
   user: User | undefined
-  token?: string
   error?: AuthError
 }
 
@@ -127,7 +126,7 @@ export const register = async (params: RegisterParams): Promise<RegisterResult> 
     if (token) {
       await setPayloadTokenCookie(token)
     }
-    return { user: user as User, token }
+    return { user: user as User }
   } catch (error) {
     const msg = error instanceof Error ? error.message : ''
     const isUploadError =

--- a/actions/auth/register.ts
+++ b/actions/auth/register.ts
@@ -115,7 +115,7 @@ export const register = async (params: RegisterParams): Promise<RegisterResult> 
       },
     })
 
-    const { token } = await payload.login({
+    const { token, exp } = await payload.login({
       collection: 'users',
       data: {
         email,
@@ -124,7 +124,7 @@ export const register = async (params: RegisterParams): Promise<RegisterResult> 
     })
 
     if (token) {
-      await setPayloadTokenCookie(token)
+      await setPayloadTokenCookie(token, exp)
     }
     return { user: user as User }
   } catch (error) {

--- a/actions/auth/register.ts
+++ b/actions/auth/register.ts
@@ -4,6 +4,7 @@ import { getPayload } from 'payload'
 import { User } from '@/payload-types'
 import { setPayloadTokenCookie } from '@/lib/auth'
 import { AuthError } from '@/lib/auth-errors'
+import { randomUUID } from 'crypto'
 
 interface RegisterResult {
   user: User | undefined
@@ -30,10 +31,11 @@ function getFileExtension(name: string): string | null {
   return match ? match[1].toLowerCase() : null
 }
 
-function buildSafeFileKey(email: string, originalName: string, timestamp: number): string {
+function buildSafeFileKey(originalName: string): string {
   const ext = getFileExtension(originalName) || 'pdf'
-  const safeEmail = email.replace(/[^a-zA-Z0-9@.]/g, '').toLowerCase() || 'user'
-  return `verification-${safeEmail}-${timestamp}.${ext}`
+  // Random, not derived from the user's email: a verification document's filename
+  // must not be guessable, since it is served from a path an attacker could enumerate.
+  return `verification-${randomUUID()}.${ext}`
 }
 
 export const register = async (params: RegisterParams): Promise<RegisterResult> => {
@@ -80,23 +82,6 @@ export const register = async (params: RegisterParams): Promise<RegisterResult> 
       return { user: undefined, error: { code: 'EMAIL_TAKEN', field: 'email' } }
     }
 
-    const safeFileName = buildSafeFileKey(email, verificationDocument.name, Date.now())
-
-    const mediaDoc = await payload.create({
-      collection: 'media',
-      draft: false,
-      data: {
-        alt: `وثيقة تحقق: ${verificationDocument.name}`,
-      },
-      filePath: undefined,
-      file: {
-        data: Buffer.from(await verificationDocument.arrayBuffer()),
-        name: safeFileName,
-        mimetype: verificationDocument.type,
-        size: verificationDocument.size,
-      },
-    })
-
     const user = await payload.create({
       collection: 'users',
       draft: false,
@@ -108,12 +93,43 @@ export const register = async (params: RegisterParams): Promise<RegisterResult> 
         faculty,
         studyYear: studyYear as '1' | '2' | '3' | '4' | '5' | undefined,
         role: 'user',
-        verificationDocument: mediaDoc.id,
         verificationStatus: 'pending_verification',
         consentGiven: true,
         consentTimestamp: new Date().toISOString(),
       },
     })
+
+    try {
+      const safeFileName = buildSafeFileKey(verificationDocument.name)
+
+      const mediaDoc = await payload.create({
+        collection: 'media',
+        draft: false,
+        data: {
+          alt: `وثيقة تحقق: ${verificationDocument.name}`,
+          isPrivate: true,
+          owner: user.id,
+        },
+        filePath: undefined,
+        file: {
+          data: Buffer.from(await verificationDocument.arrayBuffer()),
+          name: safeFileName,
+          mimetype: verificationDocument.type,
+          size: verificationDocument.size,
+        },
+      })
+
+      await payload.update({
+        collection: 'users',
+        id: user.id,
+        data: { verificationDocument: mediaDoc.id },
+      })
+    } catch (uploadError) {
+      // The account is useless without its verification document, so do not
+      // leave an orphaned pending_verification user behind.
+      await payload.delete({ collection: 'users', id: user.id }).catch(() => {})
+      throw uploadError
+    }
 
     const { token, exp } = await payload.login({
       collection: 'users',

--- a/actions/books.ts
+++ b/actions/books.ts
@@ -1,10 +1,8 @@
 'use server'
 
-import { getPayload } from 'payload'
-import payloadConfig from '@/payload.config'
-import { getAuthenticatedUser } from '@/lib/auth'
+import { getPayloadWithUser } from '@/lib/auth'
 import { revalidatePath } from 'next/cache'
-import type { Payload } from 'payload'
+import type { Payload, PayloadRequest } from 'payload'
 import type { User } from '@/payload-types'
 
 export interface ReviewBookParams {
@@ -15,10 +13,10 @@ export interface ReviewBookParams {
 
 export async function reviewBookLogic(
   params: ReviewBookParams,
-  ctx: { payload: Payload; user: User },
+  ctx: { payload: Payload; user: User; req: PayloadRequest },
 ) {
   const { bookId, rating, comment } = params
-  const { payload, user } = ctx
+  const { payload, user, req } = ctx
 
   if (!rating || !comment) {
     throw new Error('Please provide a rating and comment')
@@ -32,7 +30,7 @@ export async function reviewBookLogic(
       rating: Number(rating),
       comment,
     },
-    req: { payload, user },
+    req,
     overrideAccess: false,
   })
 
@@ -40,14 +38,13 @@ export async function reviewBookLogic(
 }
 
 export const reviewBook = async (bookId: number, rating: number, comment: string) => {
-  const payload = await getPayload({ config: payloadConfig })
-  const user = await getAuthenticatedUser()
+  const ctx = await getPayloadWithUser()
 
-  if (!user) {
+  if (!ctx) {
     throw new Error('You must be logged in to review this book')
   }
 
-  const review = await reviewBookLogic({ bookId, rating, comment }, { payload, user })
+  const review = await reviewBookLogic({ bookId, rating, comment }, ctx)
   revalidatePath(`/library/book/${bookId}`)
   return review
 }

--- a/actions/loans.ts
+++ b/actions/loans.ts
@@ -17,6 +17,10 @@ export async function borrowBookLogic(
 ): Promise<BorrowBookResult> {
   const { payload, user, req } = ctx
 
+  if (user.verificationStatus !== 'verified') {
+    return { success: false, message: 'يجب تأكيد حسابك قبل استعارة الكتب' }
+  }
+
   try {
     const bookResult = await payload.findByID({
       collection: 'books',

--- a/actions/profile/settings.ts
+++ b/actions/profile/settings.ts
@@ -1,7 +1,8 @@
 'use server'
 
-import { getPayloadWithUser } from '@/lib/auth'
+import { getPayloadWithUser, setPayloadTokenCookie } from '@/lib/auth'
 import { revalidatePath } from 'next/cache'
+import { logoutOperation } from 'payload'
 
 export async function updateProfileFullName(formData: FormData) {
   const ctx = await getPayloadWithUser()
@@ -51,6 +52,24 @@ export async function changePassword(formData: FormData) {
     req: ctx.req,
     overrideAccess: false,
   })
+
+  // A stolen session must not survive a password change: revoke every
+  // session the login check above and the old password may have left behind,
+  // then issue exactly one fresh session for this device.
+  await logoutOperation({
+    allSessions: true,
+    collection: ctx.payload.collections['users'],
+    req: ctx.req,
+  })
+
+  const { token, exp } = await ctx.payload.login({
+    collection: 'users',
+    data: { email: ctx.user.email, password: next },
+  })
+  if (token) {
+    await setPayloadTokenCookie(token, exp)
+  }
+
   revalidatePath('/user/dashboard')
   revalidatePath('/user/settings')
   return { ok: true as const }

--- a/app/(frontend)/api/oauth/google/callback/route.ts
+++ b/app/(frontend)/api/oauth/google/callback/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { getPayload } from 'payload'
+import config from '@/payload.config'
+import { createSessionForUser, setPayloadTokenCookie } from '@/lib/auth'
+import { GOOGLE_OAUTH_STATE_COOKIE, exchangeGoogleCode } from '@/lib/oauth/google'
+import type { User } from '@/payload-types'
+
+function redirectClearingState(request: NextRequest, path: string) {
+  const response = NextResponse.redirect(new URL(path, request.url))
+  response.cookies.delete(GOOGLE_OAUTH_STATE_COOKIE)
+  return response
+}
+
+export async function GET(request: NextRequest) {
+  const code = request.nextUrl.searchParams.get('code')
+  const returnedState = request.nextUrl.searchParams.get('state')
+  const expectedState = request.cookies.get(GOOGLE_OAUTH_STATE_COOKIE)?.value
+
+  if (!code || !returnedState || !expectedState || returnedState !== expectedState) {
+    return redirectClearingState(request, '/auth/login')
+  }
+
+  try {
+    const identity = await exchangeGoogleCode(code)
+
+    // Only an already-verified Google email may sign in, and only into an
+    // existing, already-registered account: Law 18-07 requires explicit
+    // consent and a reviewed verification document at signup, neither of
+    // which a Google account can supply, so this never creates a new user.
+    if (!identity || !identity.emailVerified) {
+      return redirectClearingState(request, '/auth/login')
+    }
+
+    const payload = await getPayload({ config })
+    const matches = await payload.find({
+      collection: 'users',
+      where: { email: { equals: identity.email.toLowerCase() } },
+      limit: 1,
+      overrideAccess: true,
+    })
+    const user = matches.docs[0] as User | undefined
+
+    if (!user || user.role === 'admin') {
+      return redirectClearingState(request, '/auth/login')
+    }
+
+    const { token, exp } = await createSessionForUser(payload, user)
+    await setPayloadTokenCookie(token, exp)
+
+    return redirectClearingState(request, '/user/dashboard')
+  } catch (error) {
+    console.error('Google OAuth callback error:', error)
+    return redirectClearingState(request, '/auth/login')
+  }
+}

--- a/app/(frontend)/api/oauth/google/route.ts
+++ b/app/(frontend)/api/oauth/google/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse, type NextRequest } from 'next/server'
+import { randomUUID } from 'crypto'
+import {
+  GOOGLE_OAUTH_STATE_COOKIE,
+  buildGoogleAuthorizationUrl,
+  isGoogleOAuthConfigured,
+} from '@/lib/oauth/google'
+
+export async function GET(request: NextRequest) {
+  if (!isGoogleOAuthConfigured()) {
+    return NextResponse.redirect(new URL('/auth/login', request.url))
+  }
+
+  const state = randomUUID()
+  const response = NextResponse.redirect(buildGoogleAuthorizationUrl(state))
+
+  response.cookies.set(GOOGLE_OAUTH_STATE_COOKIE, state, {
+    path: '/',
+    httpOnly: true,
+    secure: process.env.NODE_ENV !== 'development',
+    sameSite: 'lax',
+    maxAge: 60 * 10,
+  })
+
+  return response
+}

--- a/app/(frontend)/auth/layout.tsx
+++ b/app/(frontend)/auth/layout.tsx
@@ -1,14 +1,17 @@
-'use client'
-
 import React from 'react'
 import Link from 'next/link'
+import { redirect } from 'next/navigation'
 import { X } from 'lucide-react'
+import { getAuthenticatedUser } from '@/lib/auth'
 
-export default function AuthLayout({
+export default async function AuthLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
+  const user = await getAuthenticatedUser({ allowAdmin: true })
+  if (user) redirect(user.role === 'admin' ? '/admin' : '/user/dashboard')
+
   return (
     <>
       <Link

--- a/app/(frontend)/auth/login/page.tsx
+++ b/app/(frontend)/auth/login/page.tsx
@@ -22,6 +22,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { login } from "@/actions/auth/login";
+import { safeRedirect } from "@/lib/redirect";
 import { useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 
@@ -39,7 +40,7 @@ export default function LoginPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const queryClient = useQueryClient();
-  const redirect = searchParams.get("redirect") || "/user/dashboard";
+  const redirect = safeRedirect(searchParams.get("redirect"), "/user/dashboard");
 
   const form = useForm<LoginFormValues>({
     resolver: zodResolver(loginSchema),

--- a/app/(frontend)/auth/login/page.tsx
+++ b/app/(frontend)/auth/login/page.tsx
@@ -55,9 +55,6 @@ export default function LoginPage() {
       if (!result?.user) {
         toast.error("فشل تسجيل الدخول");
       } else {
-        if (result.token) {
-          localStorage.setItem("access_token", result.token);
-        }
         await queryClient.invalidateQueries({ queryKey: ["profile"] });
         toast.success("تم تسجيل الدخول بنجاح");
         router.push(result.user.role === "admin" ? "/admin" : redirect);

--- a/app/(frontend)/auth/register/page.tsx
+++ b/app/(frontend)/auth/register/page.tsx
@@ -25,6 +25,7 @@ import {
 import { useAuthFormStore } from '@/store/auth-form'
 import { register } from '@/actions/auth/register'
 import { authErrorMessage } from '@/lib/auth-errors'
+import { safeRedirect } from '@/lib/redirect'
 import LandingCtaButton from '@/components/ui/landing/LandingCtaButton'
 import { AlertCircle, Upload } from 'lucide-react'
 
@@ -74,7 +75,7 @@ export default function RegisterPage() {
   const router = useRouter()
   const searchParams = useSearchParams()
   const queryClient = useQueryClient()
-  const redirect = searchParams.get('redirect') || '/user/dashboard'
+  const redirect = safeRedirect(searchParams.get('redirect'), '/user/dashboard')
   const { step, setStep, ...formData } = useAuthFormStore()
 
   useEffect(() => {

--- a/app/(frontend)/auth/register/page.tsx
+++ b/app/(frontend)/auth/register/page.tsx
@@ -149,9 +149,6 @@ export default function RegisterPage() {
       if (!result?.user) {
         toast.error(result?.error ? authErrorMessage(result.error.code) : 'فشل إنشاء الحساب')
       } else {
-        if (result.token) {
-          localStorage.setItem('access_token', result.token)
-        }
         await queryClient.invalidateQueries({ queryKey: ['profile'] })
         toast.success('تم إنشاء الحساب بنجاح')
         router.push(redirect)

--- a/app/member-portal/layout.tsx
+++ b/app/member-portal/layout.tsx
@@ -11,8 +11,9 @@ export const metadata: Metadata = {
 }
 
 export default async function MemberPortalLayout({ children }: { children: React.ReactNode }) {
-  const user = await getAuthenticatedUser()
-  if (!user) redirect('/auth/login')
+  const user = await getAuthenticatedUser({ allowAdmin: true })
+  if (!user) redirect('/auth/login?redirect=/user/dashboard')
+  if (user.role === 'admin') redirect('/admin')
 
   const dashboard = await getProfileDashboardData()
   const activeLoans = dashboard?.loans.filter((loan) => loan.status !== 'returned').length ?? 0

--- a/collections/Media.ts
+++ b/collections/Media.ts
@@ -1,13 +1,27 @@
-import type { CollectionConfig } from 'payload'
+import type { Access, CollectionConfig, Where } from 'payload'
+import { isAdmin } from '@/utils/access-helpers'
+
+const readAccess: Access = ({ req: { user } }) => {
+  if (isAdmin(user)) return true
+
+  const notPrivate: Where = { isPrivate: { not_equals: true } }
+  if (!user) return notPrivate
+
+  const ownedByViewer: Where = { owner: { equals: user.id } }
+  return { or: [notPrivate, ownedByViewer] }
+}
 
 export const Media: CollectionConfig = {
   slug: 'media',
   admin: {
     useAsTitle: 'alt',
-    defaultColumns: ['id', 'alt', 'url', 'filename'],
+    defaultColumns: ['id', 'alt', 'url', 'filename', 'isPrivate'],
   },
   access: {
-    read: () => true,
+    read: readAccess,
+    create: ({ req: { user } }) => Boolean(user),
+    update: ({ req: { user } }) => isAdmin(user),
+    delete: ({ req: { user } }) => isAdmin(user),
   },
   upload: {
     mimeTypes: ['image/*', 'application/pdf'],
@@ -16,6 +30,30 @@ export const Media: CollectionConfig = {
     {
       name: 'alt',
       type: 'text',
+    },
+    {
+      name: 'isPrivate',
+      type: 'checkbox',
+      defaultValue: false,
+      index: true,
+      admin: {
+        description: 'وثائق التحقق من الهوية فقط. لا يمكن لغير المالك أو الإدارة الوصول إليها.',
+      },
+      access: {
+        update: ({ req: { user } }) => isAdmin(user),
+      },
+    },
+    {
+      name: 'owner',
+      type: 'relationship',
+      relationTo: 'users',
+      index: true,
+      admin: {
+        position: 'sidebar',
+      },
+      access: {
+        update: ({ req: { user } }) => isAdmin(user),
+      },
     },
   ],
 }

--- a/collections/User.ts
+++ b/collections/User.ts
@@ -1,5 +1,6 @@
 import { CollectionConfig } from 'payload'
 import { isAdmin } from '@/utils/access-helpers'
+import { TOKEN_EXPIRATION_SECONDS } from '@/utils/auth-constants'
 
 export const User: CollectionConfig = {
   slug: 'users',
@@ -19,7 +20,7 @@ export const User: CollectionConfig = {
     delete: ({ req: { user } }) => isAdmin(user),
   },
   auth: {
-    tokenExpiration: 7200,
+    tokenExpiration: TOKEN_EXPIRATION_SECONDS,
     verify: false,
     maxLoginAttempts: 5,
     lockTime: 600 * 1000,

--- a/components/layouts/navbar/Navbar.tsx
+++ b/components/layouts/navbar/Navbar.tsx
@@ -43,7 +43,6 @@ const Navbar: React.FC = () => {
 
   const onLogout = async () => {
     await logout()
-    localStorage.removeItem('access_token')
     toast.success('تم تسجيل الخروج بنجاح')
     router.push('/auth/login')
   }

--- a/components/layouts/user/UserSidebar.tsx
+++ b/components/layouts/user/UserSidebar.tsx
@@ -209,7 +209,6 @@ const SidebarLogoutCompact: React.FC = () => {
 
   const onLogout = async () => {
     await logout()
-    localStorage.removeItem('access_token')
     toast.success('تم تسجيل الخروج بنجاح')
     router.push('/auth/login')
     router.refresh()

--- a/interfaces/auth.interfaces.ts
+++ b/interfaces/auth.interfaces.ts
@@ -1,18 +1,8 @@
 import { User } from '@/payload-types'
 
-export interface AuthResponse {
+// Matches exactly what GET /api/users/me returns (app/(frontend)/api/users/me/route.ts).
+// It is not Payload's own /api/users/me response shape, which also carries the
+// session list and JWT — none of that is exposed here, on purpose.
+export interface ProfileResponse {
   user: User
-  updatedAt: string
-  createdAt: string
-  email: string
-  sessions: {
-    id: string
-    createdAt: string
-    expiresAt: string
-  }[]
-  collection: string
-  strategy: string
-  exp: number
-  token: string
-  message: string
 }

--- a/lib/apis/auth-api.ts
+++ b/lib/apis/auth-api.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQuery } from '@tanstack/react-query'
-import { AuthResponse } from '@/interfaces/auth.interfaces'
+import { ProfileResponse } from '@/interfaces/auth.interfaces'
 import { httpClient } from './http-client'
 
 export const authKeys = {
@@ -11,7 +11,7 @@ export async function logoutRequest() {
 }
 
 export async function fetchProfile() {
-  return httpClient.get<AuthResponse>('/users/me', { useAuth: false })
+  return httpClient.get<ProfileResponse>('/users/me', { useAuth: false })
 }
 
 export function useLogoutMutation() {

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -4,6 +4,7 @@ import config from '@/payload.config'
 import { headers as nextHeaders, cookies as nextCookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 import type { User } from '@/payload-types'
+import { TOKEN_EXPIRATION_SECONDS } from '@/utils/auth-constants'
 
 export interface AuthOptions {
   allowAdmin?: boolean
@@ -52,14 +53,18 @@ export async function requireUser(redirectTo = '/auth', opts?: AuthOptions) {
   return ctx
 }
 
-export async function setPayloadTokenCookie(token: string) {
+export async function setPayloadTokenCookie(token: string, exp?: number) {
   const cookieStore = await nextCookies()
+  const maxAge = exp
+    ? Math.max(0, exp - Math.floor(Date.now() / 1000))
+    : TOKEN_EXPIRATION_SECONDS
+
   cookieStore.set('payload-token', token, {
     path: '/',
     httpOnly: true,
-    secure: process.env.NODE_ENV === 'production',
-    sameSite: 'strict',
-    maxAge: 60 * 60 * 24 * 7,
+    secure: process.env.NODE_ENV !== 'development',
+    sameSite: 'lax',
+    maxAge,
   })
 }
 

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,8 +1,9 @@
-import { createLocalReq, getPayload } from 'payload'
+import { createLocalReq, getFieldsToSign, getPayload, jwtSign } from 'payload'
 import type { Payload, PayloadRequest } from 'payload'
 import config from '@/payload.config'
 import { headers as nextHeaders, cookies as nextCookies } from 'next/headers'
 import { redirect } from 'next/navigation'
+import { randomUUID } from 'crypto'
 import type { User } from '@/payload-types'
 import { TOKEN_EXPIRATION_SECONDS } from '@/utils/auth-constants'
 
@@ -70,4 +71,47 @@ export async function setPayloadTokenCookie(token: string, exp?: number) {
 
 export function isAdmin(user: { role?: string } | null | undefined): boolean {
   return user?.role === 'admin'
+}
+
+/**
+ * Issues a real Payload session (JWT + `sessions` array entry) for a user who has
+ * already proven their identity through another channel, without a password
+ * check — used by the Google OAuth callback. This mirrors what
+ * `payload.login()` does internally (see `payload/dist/auth/operations/login.js`),
+ * since the Local API has no "log this known user in" operation for
+ * password-based collections.
+ */
+export async function createSessionForUser(
+  payload: Payload,
+  user: User,
+): Promise<{ token: string; exp: number }> {
+  const collectionConfig = payload.collections['users'].config
+  const sid = randomUUID()
+  const now = new Date()
+  const expiresAt = new Date(now.getTime() + TOKEN_EXPIRATION_SECONDS * 1000)
+  const activeSessions = (user.sessions ?? []).filter(
+    (session) => new Date(session.expiresAt) > now,
+  )
+
+  await payload.update({
+    collection: 'users',
+    id: user.id,
+    data: {
+      sessions: [...activeSessions, { id: sid, createdAt: now.toISOString(), expiresAt: expiresAt.toISOString() }],
+    },
+    overrideAccess: true,
+  })
+
+  const fieldsToSign = getFieldsToSign({
+    collectionConfig,
+    email: user.email,
+    sid,
+    user,
+  })
+
+  return jwtSign({
+    fieldsToSign,
+    secret: payload.secret,
+    tokenExpiration: TOKEN_EXPIRATION_SECONDS,
+  })
 }

--- a/lib/oauth/google.ts
+++ b/lib/oauth/google.ts
@@ -1,0 +1,76 @@
+const GOOGLE_AUTH_ENDPOINT = 'https://accounts.google.com/o/oauth2/v2/auth'
+const GOOGLE_TOKEN_ENDPOINT = 'https://oauth2.googleapis.com/token'
+const GOOGLE_USERINFO_ENDPOINT = 'https://www.googleapis.com/oauth2/v3/userinfo'
+
+export const GOOGLE_OAUTH_STATE_COOKIE = 'google-oauth-state'
+
+function getRedirectUri(): string {
+  const serverUrl = process.env.NEXT_PUBLIC_SERVER_URL || 'http://localhost:3000'
+  return `${serverUrl}/api/oauth/google/callback`
+}
+
+export function isGoogleOAuthConfigured(): boolean {
+  return Boolean(process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET)
+}
+
+export function buildGoogleAuthorizationUrl(state: string): string {
+  const url = new URL(GOOGLE_AUTH_ENDPOINT)
+  url.searchParams.set('client_id', process.env.GOOGLE_CLIENT_ID || '')
+  url.searchParams.set('redirect_uri', getRedirectUri())
+  url.searchParams.set('response_type', 'code')
+  url.searchParams.set('scope', 'openid email profile')
+  url.searchParams.set('access_type', 'online')
+  url.searchParams.set('prompt', 'select_account')
+  url.searchParams.set('state', state)
+  return url.toString()
+}
+
+interface GoogleIdentity {
+  email: string
+  emailVerified: boolean
+  name?: string
+}
+
+/**
+ * Exchanges an authorization code for the caller's verified Google identity.
+ * The trust boundary is the direct, server-to-server HTTPS call to Google below,
+ * not a locally-verified ID token, which keeps this dependency-free.
+ */
+export async function exchangeGoogleCode(code: string): Promise<GoogleIdentity | null> {
+  const tokenResponse = await fetch(GOOGLE_TOKEN_ENDPOINT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      client_id: process.env.GOOGLE_CLIENT_ID || '',
+      client_secret: process.env.GOOGLE_CLIENT_SECRET || '',
+      code,
+      grant_type: 'authorization_code',
+      redirect_uri: getRedirectUri(),
+    }),
+  })
+
+  if (!tokenResponse.ok) return null
+
+  const tokenBody = (await tokenResponse.json()) as { access_token?: string }
+  if (!tokenBody.access_token) return null
+
+  const userInfoResponse = await fetch(GOOGLE_USERINFO_ENDPOINT, {
+    headers: { Authorization: `Bearer ${tokenBody.access_token}` },
+  })
+
+  if (!userInfoResponse.ok) return null
+
+  const userInfo = (await userInfoResponse.json()) as {
+    email?: string
+    email_verified?: boolean
+    name?: string
+  }
+
+  if (!userInfo.email) return null
+
+  return {
+    email: userInfo.email,
+    emailVerified: Boolean(userInfo.email_verified),
+    name: userInfo.name,
+  }
+}

--- a/lib/redirect.ts
+++ b/lib/redirect.ts
@@ -5,3 +5,11 @@ export function redirectToLogin() {
     window.location.replace(loginUrl);
   }
 }
+
+// Only ever follow a same-site, relative path. A `redirect` search param is
+// attacker-controlled input, so `?redirect=https://evil.example` must not
+// send a just-authenticated user off site.
+export function safeRedirect(value: string | null | undefined, fallback: string): string {
+  if (!value || !value.startsWith("/") || value.startsWith("//")) return fallback;
+  return value;
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -35,17 +35,8 @@ const nextConfig: NextConfig = {
         port: '3000',
         pathname: '/api/media/file/**',
       },
-      {
-        protocol: 'http',
-        hostname: '127.0.0.1',
-        port: '54321',
-        pathname: '/storage/v1/object/**',
-      },
-      {
-        protocol: 'https',
-        hostname: '*.supabase.co',
-        pathname: '/storage/v1/object/**',
-      },
+      // No direct storage bucket patterns here on purpose: media is always
+      // served through /api/media/file/** so collection access control applies.
     ],
   },
   headers: async () => {

--- a/payload-types.ts
+++ b/payload-types.ts
@@ -198,6 +198,11 @@ export interface User {
 export interface Media {
   id: number;
   alt?: string | null;
+  /**
+   * وثائق التحقق من الهوية فقط. لا يمكن لغير المالك أو الإدارة الوصول إليها.
+   */
+  isPrivate?: boolean | null;
+  owner?: (number | null) | User;
   prefix?: string | null;
   updatedAt: string;
   createdAt: string;
@@ -602,6 +607,8 @@ export interface UsersSelect<T extends boolean = true> {
  */
 export interface MediaSelect<T extends boolean = true> {
   alt?: T;
+  isPrivate?: T;
+  owner?: T;
   prefix?: T;
   updatedAt?: T;
   createdAt?: T;

--- a/proxy.ts
+++ b/proxy.ts
@@ -3,7 +3,11 @@ import type { NextRequest } from 'next/server'
 
 const protectedRoutes = ['/user', '/library/book-requests']
 
-export function middleware(request: NextRequest) {
+// This is a UX redirect only, not the security boundary: it just checks the
+// cookie is present. Every server action, route handler and data read still
+// re-verifies the session itself (see lib/auth.ts), since a matcher change
+// here must never be the only thing standing between a request and private data.
+export function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl
   const token = request.cookies.get('payload-token')?.value
 

--- a/utils/auth-constants.ts
+++ b/utils/auth-constants.ts
@@ -1,0 +1,4 @@
+// Single source of truth for how long a member session lasts. Shared by
+// `collections/User.ts#auth.tokenExpiration` and `lib/auth.ts#setPayloadTokenCookie`
+// so the session cookie never outlives the JWT it carries.
+export const TOKEN_EXPIRATION_SECONDS = 60 * 60 * 24 * 7


### PR DESCRIPTION
Closes #90.

## Summary

- Stop copying the session JWT into `localStorage` (`access_token`); the httpOnly cookie was already the only real session.
- Sync the session cookie's lifetime to the token's own expiry, so a session no longer outlives its cookie or vice versa, and share one `TOKEN_EXPIRATION_SECONDS` constant between `collections/User.ts` and `lib/auth.ts`.
- Logout now actually revokes the server-side session (Payload's `useSessions`), instead of only deleting the cookie.
- Verification documents in `media` are now private by default (`isPrivate` + `owner` fields with row-level access): only the uploading member and admins can read them, filenames are random instead of derived from the user's email, and direct storage-bucket URLs were dropped from `next.config.ts` so `/api/media/file/**` access control can't be bypassed.
- Fixed an open redirect on `/auth/login` and `/auth/register` (`?redirect=` is now validated as a same-site path).
- Signed-in users are redirected away from `/auth/*` (admins to `/admin`, members to `/user/dashboard`), and an admin visiting `/user/*` now lands on `/admin` instead of being bounced to the login page.
- Borrowing a book now requires `verificationStatus === 'verified'`.
- Changing your password now revokes every existing session and issues exactly one fresh one, so a stolen session doesn't survive a password change.
- `reviewBook` now runs through a real `PayloadRequest` (via `getPayloadWithUser`) instead of a fake `{ payload, user }` object.
- The `/api/users/me` response type now matches what the route actually returns.
- Implemented the Google OAuth login button for real: it signs in an existing, already-verified member by email (never auto-creates an account, since Law 18-07 requires explicit consent and a reviewed verification document at signup) and mints a normal Payload session through the same session/cookie path as password login. No UI was touched — the existing button and login page are unchanged.
- Migrated `middleware.ts` to Next.js 16's `proxy.ts` convention.

## Verification

No test suite exists in this repo (per `CLAUDE.md`), so this was verified against a local Supabase stack with `pnpm dev:full`, using the real login/register/logout/password-change flows and direct Postgres queries against `users_sessions`:

- Login sets a session that expires with the cookie (confirmed via DB row `expires_at`).
- Logout removes the session row; replaying the old cookie afterward gets 401.
- A verification document is 403 for an anonymous request and for a different signed-in member, 200 for its owner.
- `?redirect=https://evil.example` on login lands on `/user/dashboard`.
- A signed-in admin hitting `/auth/login` or `/user/dashboard` lands on `/admin`; a signed-in member hitting `/auth/login` lands on `/user/dashboard`.
- An unverified account is blocked from borrowing with the correct message; a verified one succeeds.
- Changing the password rejects the old password afterward, accepts the new one, and leaves exactly one active session.
- The Google OAuth entry route redirects to Google with the correct `client_id`/`redirect_uri`/`scope`/`state`; the callback's session-minting path was verified end to end (existing verified user gets a real, working session; unknown email and admin email are both rejected).

`pnpm lint` and `pnpm typecheck` pass. `pnpm build` fails identically on `dev` (pre-existing, requires `BLOB_READ_WRITE_TOKEN` which only Vercel provides) — CI only runs lint + typecheck, per `CLAUDE.md`.

## Out of scope

Password reset (forgot/reset password) needs new UI and was intentionally left out, since the instruction for this PR was backend/logic changes only, no UI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
